### PR TITLE
Use Erlang's :gen_event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,15 +54,6 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - name: Retrieve caches
-        uses: actions/cache@v2
-        id: mix-cache
-        with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: Get Deps
         run: mix deps.get
       - name: Compile Deps
@@ -78,7 +69,6 @@ jobs:
       - name: Generate Docs
         run: mix docs --output test/doc
       # - name: Create PLTs
-      #   if: steps.mix-cache.outputs.cache-hit != 'true'
       #   run: |
       #     mkdir -p priv/plts
       #     mix dialyzer --plt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,8 @@ jobs:
       #   run: mix credo --strict
       - name: Check Format
         run: mix format --check-formatted
-      # - name: Run Coveralls
-      #   run: mix coveralls --raise
+      - name: Run Coveralls
+        run: mix coveralls
       - name: Generate Docs
         run: mix docs --output test/doc
       # - name: Create PLTs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
+/cover
 erl_crash.dump
 *.ez
 mix.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog for v0.x
 
+## v0.9.0 (2021-06-04)
+
+Fixes deprecations and improves testing.
+
+### Enhancements
+
+  * [Airbrake.Worker] Abstract HTTP client for better testing using `mox`.
+  * [Airbrake.Worker] Add tests.
+  * [Airbrake.LoggerBackend] Add tests.
+  * [Airbrake.LoggerBackend] Use `@behaviour :gen_event` instead of `use GenEvent`.
+  * [mix.exs] Start dependency applications automatically.
+
+### Bug fixes
+
+  * [Airbrake.Channel] Use `__STACKTRACE__` instead of deprecated `System.stacktrace()`.
+  * [Airbrake.Worker] Use `Process.info(self(), :current_stacktrace)` instead of deprecated `System.stacktrace()`.
+  * [Airbrake] Use child spec instead of deprecated `Supervisor.Spec.worker/1`.
+
 ## v0.8.2 (2021-06-03)
 
 Renames the app to `:airbrake_client`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `airbrake_client` to your dependencies:
 ```elixir
 defp deps do
   [
-    {:airbrake_client, "~> 0.8"}
+    {:airbrake_client, "~> 0.9"}
   ]
 end
 ```
@@ -27,6 +27,8 @@ If you are switching from the original `airbrake` library:
 
 1. Replace the `:airbrake` dependency with the `:airbrake_client` dependency
    above.
+    * You may want to start with version `~> 0.8.0` for maximum backwards
+      compatibility.
 1. Remove the `airbrake` dependency in your lockfile.
     * Command: `mix deps.unlock --unused`
     * If the dependency remains in the lockfile, check _all_ of your apps and

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,6 @@ config :airbrake_client,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
   host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
-  http_adapter: HTTPoison
+  private: [http_adapter: HTTPoison]
 
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,7 @@ use Mix.Config
 config :airbrake_client,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
-  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"}
+  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
+  http_adapter: HTTPoison
+
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :airbrake_client,
+  http_adapter: Airbrake.HTTPMock

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
 config :airbrake_client,
-  http_adapter: Airbrake.HTTPMock
+  private: [http_adapter: Airbrake.HTTPMock]

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,6 @@
+{
+  "skip_files": [
+    "deps",
+    "test"
+  ]
+}

--- a/lib/airbrake.ex
+++ b/lib/airbrake.ex
@@ -17,7 +17,7 @@ defmodule Airbrake do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(Airbrake.Worker, [])
+      Airbrake.Worker
     ]
 
     opts = [strategy: :one_for_one, name: Airbrake.Supervisor]

--- a/lib/airbrake/channel.ex
+++ b/lib/airbrake/channel.ex
@@ -34,7 +34,7 @@ defmodule Airbrake.Channel do
           super(channel_name, msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, msg, %{channel: channel_name})
+            send_to_airbrake(exception, __STACKTRACE__, socket.assigns, msg, %{channel: channel_name})
         end
       end
 
@@ -43,7 +43,7 @@ defmodule Airbrake.Channel do
           super(msg_type, msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, msg, %{msg_type: msg_type})
+            send_to_airbrake(exception, __STACKTRACE__, socket.assigns, msg, %{msg_type: msg_type})
         end
       end
 
@@ -52,7 +52,7 @@ defmodule Airbrake.Channel do
           super(msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, msg)
+            send_to_airbrake(exception, __STACKTRACE__, socket.assigns, msg)
         end
       end
 
@@ -61,13 +61,11 @@ defmodule Airbrake.Channel do
           super(reason, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, %{reason: reason})
+            send_to_airbrake(exception, __STACKTRACE__, socket.assigns, %{reason: reason})
         end
       end
 
-      defp send_to_airbrake(exception, session, params, context \\ nil) do
-        stacktrace = System.stacktrace()
-
+      defp send_to_airbrake(exception, stacktrace, session, params, context \\ nil) do
         Airbrake.Worker.remember(exception,
           params: params,
           session: session,

--- a/lib/airbrake/logger_backend.ex
+++ b/lib/airbrake/logger_backend.ex
@@ -1,6 +1,7 @@
 defmodule Airbrake.LoggerBackend do
   @moduledoc false
-  use GenEvent
+
+  @behaviour :gen_event
 
   def init({__MODULE__, _name}) do
     {:ok, nil}

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -25,7 +25,7 @@ defmodule Airbrake.Worker do
   end
 
   def report([type: _, message: _] = exception, options) when is_list(options) do
-    stacktrace = options[:stacktrace] || System.stacktrace()
+    stacktrace = options[:stacktrace] || get_stacktrace()
     GenServer.cast(@name, {:report, exception, stacktrace, Keyword.delete(options, :stacktrace)})
   end
 
@@ -114,6 +114,10 @@ defmodule Airbrake.Worker do
       _ ->
         current_options
     end
+  end
+
+  defp get_stacktrace do
+    Process.info(self(), :current_stacktrace)
   end
 
   defp ignore?(type: type, message: message) do

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -10,6 +10,7 @@ defmodule Airbrake.Worker do
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
   @default_host "https://airbrake.io"
+  @http_adapter Application.get_env(:airbrake_client, :http_adapter)
 
   @doc """
   Send a report to Airbrake.
@@ -96,7 +97,7 @@ defmodule Airbrake.Worker do
       enhanced_options = build_options(options)
       payload = Airbrake.Payload.new(exception, stacktrace, enhanced_options)
       json_encoder = Application.get_env(:airbrake_client, :json_encoder, Poison)
-      HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
+      @http_adapter.post(notify_url(), json_encoder.encode!(payload), @request_headers)
     end
   end
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -53,6 +53,10 @@ defmodule Airbrake.Worker do
   end
 
   def start_link do
+    start_link([])
+  end
+
+  def start_link([]) do
     GenServer.start_link(@name, %State{}, name: @name)
   end
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -10,7 +10,9 @@ defmodule Airbrake.Worker do
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
   @default_host "https://airbrake.io"
-  @http_adapter Application.get_env(:airbrake_client, :http_adapter)
+  @http_adapter :airbrake_client
+                |> Application.get_env(:private, [])
+                |> Keyword.get(:http_adapter, HTTPoison)
 
   @doc """
   Send a report to Airbrake.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.8.2",
+      version: "0.9.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Airbrake.Mixfile do
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
+      aliases: aliases(),
       description: """
         Elixir notifier to Airbrake.io (or Errbit) with plugs for Phoenix for automatic reporting.
       """,
@@ -53,6 +54,12 @@ defmodule Airbrake.Mixfile do
       {:poison, ">= 2.0.0", optional: true},
       {:ex_doc, "~> 0.19", only: [:dev, :test]},
       {:excoveralls, "~> 0.12.0", only: :test}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --no-start"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,14 @@ defmodule Airbrake.Mixfile do
         Elixir notifier to Airbrake.io (or Errbit) with plugs for Phoenix for automatic reporting.
       """,
       deps: deps(),
-      docs: docs()
+      docs: docs(),
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 
@@ -38,8 +45,10 @@ defmodule Airbrake.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.9 or ~> 1.0"},
+      {:mox, "~> 0.5", only: :test},
       {:poison, ">= 2.0.0", optional: true},
-      {:ex_doc, "~> 0.19", only: [:dev, :test]}
+      {:ex_doc, "~> 0.19", only: [:dev, :test]},
+      {:excoveralls, "~> 0.12.0", only: :test}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Airbrake.Mixfile do
   end
 
   def application do
-    [mod: {Airbrake, []}, applications: [:httpoison]]
+    [mod: {Airbrake, []}]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Airbrake.Mixfile do
       app: :airbrake_client,
       version: "0.8.2",
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       description: """
         Elixir notifier to Airbrake.io (or Errbit) with plugs for Phoenix for automatic reporting.
@@ -41,6 +42,9 @@ defmodule Airbrake.Mixfile do
   def application do
     [mod: {Airbrake, []}, applications: [:httpoison]]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [

--- a/test/airbrake/logger_backend_test.exs
+++ b/test/airbrake/logger_backend_test.exs
@@ -1,0 +1,38 @@
+defmodule Airbrake.LoggerBackendTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+  import ExUnit.CaptureLog
+  require Logger
+
+  alias Airbrake.{LoggerBackend, HTTPMock}
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    Logger.add_backend({LoggerBackend, :error})
+    :ok
+  end
+
+  describe "error handling" do
+    test "sends the error via the HTTP handler" do
+      caller = self()
+      error_message = "** (FunctionClauseError) no function clause matching in Enum.join/2"
+
+      expected_payload_errors =
+        "\"errors\":[{\"type\":\"FunctionClauseError\",\"message\":\"no function clause matching in Enum.join/2\",\"backtrace\":[]}]"
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        assert payload =~ expected_payload_errors
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      assert capture_log(fn ->
+               Logger.error(error_message)
+             end) =~ error_message
+
+      assert_receive(url: _url, payload: _http_payload)
+    end
+  end
+end

--- a/test/airbrake/logger_backend_test.exs
+++ b/test/airbrake/logger_backend_test.exs
@@ -11,6 +11,7 @@ defmodule Airbrake.LoggerBackendTest do
 
   setup do
     Logger.add_backend({LoggerBackend, :error})
+    Airbrake.start()
     :ok
   end
 

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -6,7 +6,7 @@ defmodule Airbrake.PayloadTest do
     try do
       # If the following line is not on line 9 then tests will start failing.
       # You've been warned!
-      Harbour.cats(3)
+      apply(Harbour, :cats, [3])
     rescue
       exception -> [exception, System.stacktrace()]
     end
@@ -64,7 +64,7 @@ defmodule Airbrake.PayloadTest do
   test "it generates correct stacktraces when the method arguments are in place of arity" do
     {exception, stacktrace} =
       try do
-        Fart.poo(:butts, 1, "foo\n")
+        apply(Foo, :bar, [:qux, 1, "foo\n"])
       rescue
         exception -> {exception, System.stacktrace()}
       end
@@ -72,7 +72,7 @@ defmodule Airbrake.PayloadTest do
     %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
 
     assert [
-             %{file: "unknown", line: 0, function: "Elixir.Fart.poo(:butts, 1, \"foo\\n\")"},
+             %{file: "unknown", line: 0, function: "Elixir.Foo.bar(:qux, 1, \"foo\\n\")"},
              %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
            ] = stacktrace
   end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -8,7 +8,7 @@ defmodule Airbrake.PayloadTest do
       # You've been warned!
       apply(Harbour, :cats, [3])
     rescue
-      exception -> [exception, System.stacktrace()]
+      exception -> [exception, __STACKTRACE__]
     end
   end
 
@@ -36,7 +36,7 @@ defmodule Airbrake.PayloadTest do
       try do
         Enum.join(3, 'million')
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
@@ -66,7 +66,7 @@ defmodule Airbrake.PayloadTest do
       try do
         apply(Foo, :bar, [:qux, 1, "foo\n"])
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -86,8 +86,12 @@ defmodule Airbrake.WorkerTest do
   defp atomize_keys(other), do: other
 
   defp start_worker do
-    {:ok, worker_pid} = Airbrake.Worker.start_link()
-    worker_pid
+    start_result = Airbrake.Worker.start_link()
+
+    case start_result do
+      {:ok, worker_pid} -> worker_pid
+      {:error, {:already_started, worker_pid}} -> worker_pid
+    end
   end
 
   defp maybe_stop_worker do

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -1,0 +1,63 @@
+defmodule Airbrake.WorkerTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Airbrake.{HTTPMock, Payload}
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    {exception, stacktrace} =
+      try do
+        Enum.join(3, 'million')
+      rescue
+        exception -> {exception, System.stacktrace()}
+      end
+
+    [exception: exception, stacktrace: stacktrace]
+  end
+
+  describe "report/1" do
+    test "sends the exception and stacktrace to Airbrake", %{exception: exception, stacktrace: stacktrace} do
+      expected_payload =
+        exception
+        |> Payload.new(stacktrace)
+        |> Map.from_struct()
+
+      caller = self()
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      Airbrake.Worker.report(exception)
+
+      assert_receive(url: url, payload: http_payload)
+
+      decoded_http_payload =
+        http_payload
+        |> Poison.decode!()
+        |> atomize_keys()
+
+      assert url =~ "/api/v3/projects/"
+      assert url =~ "/notices?key="
+      assert decoded_http_payload == expected_payload
+      assert decoded_http_payload == expected_payload
+    end
+  end
+
+  @spec atomize_keys(any()) :: map()
+  defp atomize_keys(map = %{}) do
+    map
+    |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), atomize_keys(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp atomize_keys([head | rest]) do
+    [atomize_keys(head) | atomize_keys(rest)]
+  end
+
+  defp atomize_keys(other), do: other
+end

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -8,12 +8,16 @@ defmodule Airbrake.WorkerTest do
   setup [:set_mox_global, :verify_on_exit!]
 
   setup do
+    start_worker()
+
     {exception, stacktrace} =
       try do
         Enum.join(3, 'million')
       rescue
         exception -> {exception, System.stacktrace()}
       end
+
+    on_exit(&maybe_stop_worker/0)
 
     [exception: exception, stacktrace: stacktrace]
   end
@@ -60,4 +64,26 @@ defmodule Airbrake.WorkerTest do
   end
 
   defp atomize_keys(other), do: other
+
+  defp start_worker do
+    {:ok, worker_pid} = Airbrake.Worker.start_link()
+    worker_pid
+  end
+
+  defp maybe_stop_worker do
+    pid_to_stop = GenServer.whereis(Airbrake.Worker)
+
+    case pid_to_stop do
+      nil -> :ok
+      _ -> stop_worker(pid_to_stop)
+    end
+  end
+
+  defp stop_worker(pid_to_stop) do
+    try do
+      GenServer.stop(pid_to_stop, :normal, 1_000)
+    catch
+      :exit, _ -> :ok
+    end
+  end
 end

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -15,7 +15,7 @@ defmodule Airbrake.WorkerTest do
       try do
         Enum.join(3, 'million')
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     on_exit(&maybe_stop_worker/0)

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -37,7 +37,7 @@ defmodule Airbrake.WorkerTest do
         {:ok, %{status_code: 204}}
       end)
 
-      Airbrake.Worker.report(exception)
+      Airbrake.Worker.report(exception, stacktrace: stacktrace)
 
       assert_receive(url: url, payload: http_payload)
 

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -67,7 +67,7 @@ defmodule Airbrake.WorkerTest do
 
       Airbrake.Worker.remember(exception)
 
-      assert %State{last_exception: {last_exception, options}} = :sys.get_state(worker_pid)
+      assert %State{last_exception: {last_exception, _options}} = :sys.get_state(worker_pid)
       assert last_exception == expected_state
     end
   end

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -49,7 +49,6 @@ defmodule Airbrake.WorkerTest do
       assert url =~ "/api/v3/projects/"
       assert url =~ "/notices?key="
       assert decoded_http_payload == expected_payload
-      assert decoded_http_payload == expected_payload
     end
   end
 

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -10,6 +10,7 @@ defmodule AirbrakeTest do
       {:ok, %{status_code: 204}}
     end)
 
+    Airbrake.start()
     :ok
   end
 

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -1,5 +1,17 @@
 defmodule AirbrakeTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    stub(Airbrake.HTTPMock, :post, fn _url, _payload, _headers ->
+      {:ok, %{status_code: 204}}
+    end)
+
+    :ok
+  end
 
   test "it doesn't raise errors if you send invalid arguments to Airbrake.report/2" do
     Airbrake.report(Enum, %{ignore: :this_error_in_test})

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -24,7 +24,7 @@ defmodule AirbrakeTest do
 
   test "it handles real errors" do
     try do
-      Airbrake.undefined_method()
+      apply(Airbrake, :undefined_method, [])
     rescue
       exception -> Airbrake.report(exception)
     end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(Airbrake.HTTPMock, for: HTTPoison.Base)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
 Airbrake.start()
+Application.ensure_all_started(:mox)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,2 @@
 ExUnit.start()
-Airbrake.start()
 Application.ensure_all_started(:mox)


### PR DESCRIPTION
Cliff McIntosh has a PR to use `:gen_server` instead of the deprecated `GenServer`.  He posted this PR to the original `airbrake` project: https://github.com/romul/airbrake-elixir/pull/12.

I've taken Cliff's branch from his fork and added it to our new repo.  I also added a few more commits to handle `__STACKTRACE__` and child specs.