### PR TITLE
Issue 8 :: fix "readme" case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for v0.x
 
+## v0.8.1 (2021-06-02)
+
+Quick documentation fix.
+
+### Bug fixes
+
+  * [README.md] Use correct case when linking to `readme.html`.
+
 ## v0.8.0 (2021-06-02)
 
 The first official release of `airbrake_client` (forked and disconnected from [`airbrake`](https://hex.pm/packages/airbrake)).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.7",
       package: package(),
       description: """

--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,8 @@ defmodule Airbrake.Mixfile do
 
   defp docs do
     [
-      extras: ["README.md", "CHANGELOG.md"],
-      main: "README"
+      main: "readme",
+      extras: ["README.md", "CHANGELOG.md"]
     ]
   end
 


### PR DESCRIPTION
`README.md` becomes `readme.html` when the docs are generated, and we need to link to `readme`, not `README`.

See Issue #8 for excruciating detail.

Closes #8.