### PR TITLE
Issue 10 :: rename the app as `airbrake_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for v0.x
 
+## v0.8.2 (2021-06-03)
+
+Renames the app to `:airbrake_client`.
+
+### Bug fixes
+
+  * [mix.exs] Renames the app to `:airbrake_client` so that starting the app for this library is more natural.
+
 ## v0.8.1 (2021-06-02)
 
 Quick documentation fix.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,26 @@ defp deps do
 end
 ```
 
-If you are switching from the original `airbrake` library, you should only have
-to switch the dependency to `:airbrake_client`.  Version 0.8.0 of this library
-(its first) should be a drop-in replacement.
+### Migrating from `airbrake`
+
+If you are switching from the original `airbrake` library:
+
+1. Replace the `:airbrake` dependency with the `:airbrake_client` dependency
+   above.
+1. Remove the `airbrake` dependency in your lockfile.
+    * Command: `mix deps.unlock --unused`
+    * If the dependency remains in the lockfile, check _all_ of your apps and
+      _all_ of your dependencies.
+1. Update your `config/*.exs` files to configure `:airbrake_client` instead of
+   `:airbrake`.
+    * A search-and-replace-in-project on `config :airbrake` can work really well.
+    * When you run your project(even running the tests), you should get a
+      complaint if you're still configuring `:airbrake`.
 
 ## Configuration
 
-Configure `:airbrake`:
-
 ```elixir
-config :airbrake,
+config :airbrake_client,
   api_key: System.get_env("AIRBRAKE_API_KEY"),
   project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
   environment: Mix.env(),
@@ -66,14 +76,14 @@ To ignore some exceptions use the `:ignore` config key.  The value can be a
 `MapSet`:
 
 ```elixir
-config :airbrake,
+config :airbrake_client,
   ignore: MapSet.new(["Custom.Error"])
 ```
 
 The value can also be a two-argument function:
 
 ```elixir
-config :airbrake,
+config :airbrake_client,
   ignore: fn type, message ->
     type == "Custom.Error" && String.contains?(message, "silent error")
   end
@@ -83,7 +93,7 @@ Or the value can be the atom `:all` to ignore all errors (and effectively
 turning off all reporting):
 
 ```elixir
-config :airbrake,
+config :airbrake_client,
   ignore: :all
 ```
 
@@ -94,7 +104,7 @@ config with the `:options` key.  Its value should be a keyword list with any of
 these keys: `:context`, `:params`, `:session`, and `:env`.
 
 ```elixir
-config :airbrake,
+config :airbrake_client,
   options: [env: %{"SOME_ENVIRONMENT_VARIABLE" => "environment variable"}]
 ```
 
@@ -102,7 +112,7 @@ Alternatively, you can specify a function (as a tuple) which returns a keyword
 list (with the same keys):
 
 ```elixir
-config :airbrake,
+config :airbrake_client,
   options: {Web, :airbrake_options, 1}
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :airbrake,
+config :airbrake_client,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
   host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"}

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -47,7 +47,7 @@ defmodule Airbrake.Payload do
   end
 
   defp env do
-    case Application.get_env(:airbrake, :environment) do
+    case Application.get_env(:airbrake_client, :environment) do
       nil -> hostname()
       {:system, var} -> System.get_env(var) || hostname()
       atom_env when is_atom(atom_env) -> to_string(atom_env)

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -95,7 +95,7 @@ defmodule Airbrake.Worker do
     unless ignore?(exception) do
       enhanced_options = build_options(options)
       payload = Airbrake.Payload.new(exception, stacktrace, enhanced_options)
-      json_encoder = Application.get_env(:airbrake, :json_encoder, Poison)
+      json_encoder = Application.get_env(:airbrake_client, :json_encoder, Poison)
       HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
     end
   end
@@ -130,7 +130,7 @@ defmodule Airbrake.Worker do
   end
 
   def get_env(key, default \\ nil) do
-    :airbrake
+    :airbrake_client
     |> Application.get_env(key, default)
     |> process_env()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.8.1",
+      version: "0.8.2",
       elixir: "~> 1.7",
       package: package(),
       description: """

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Airbrake.Mixfile do
 
   def project do
     [
-      app: :airbrake,
+      app: :airbrake_client,
       version: "0.8.1",
       elixir: "~> 1.7",
       package: package(),
@@ -24,7 +24,6 @@ defmodule Airbrake.Mixfile do
 
   def package do
     [
-      name: "airbrake_client",
       contributors: ["Jeremy D. Frens", "Clifton McIntosh", "Roman Smirnov"],
       maintainers: ["CityBase, Inc."],
       licenses: ["LGPL"],

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -91,10 +91,10 @@ defmodule Airbrake.PayloadTest do
   end
 
   test "it filters sensitive params" do
-    Application.put_env(:airbrake, :filter_parameters, ["password"])
+    Application.put_env(:airbrake_client, :filter_parameters, ["password"])
     payload = get_payload(params: %{"password" => "top_secret", "x" => "y"})
     assert "[FILTERED]" == payload.params["password"]
     assert "y" == payload.params["x"]
-    Application.delete_env(:airbrake, :filter_parameters)
+    Application.delete_env(:airbrake_client, :filter_parameters)
   end
 end


### PR DESCRIPTION
Having different names for hex and the app is non-standard.  Issue #10 describes the problems.  This PR fixes the problem by renaming the app to `:airbrake_client`.  The cost of renaming `:airbrake` to `:airbrake_config` in apps that depend on `:airbrake_client` isn't that high, so it breaks the "drop-in" replacement goal (by not by much).

Instructions in the README are updated.

Closes #10.