### PR TITLE
issue-14 :: fix the default stacktrace in Airbrake.report/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for v0.x
 
+## IN PROGRESS
+
+### Bug fixes
+
+  * [Airbrake.Worker] Generate a useable stacktrace when one isn't provided in the options.
+
 ## v0.9.0 (2021-06-04)
 
 Fixes deprecations and improves testing.
@@ -16,7 +22,7 @@ Fixes deprecations and improves testing.
 
   * [Airbrake.Channel] Use `__STACKTRACE__` instead of deprecated `System.stacktrace()`.
   * [Airbrake.Worker] Use `Process.info(self(), :current_stacktrace)` instead of deprecated `System.stacktrace()`.
-  * [Airbrake] Use child spec instead of deprecated `Supervisor.Spec.worker/1`.
+  * [Airbrake] Use child spec instead of deprecated Supervisor.Spec.worker/1.
 
 ## v0.8.2 (2021-06-03)
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -121,7 +121,8 @@ defmodule Airbrake.Worker do
   end
 
   defp get_stacktrace do
-    Process.info(self(), :current_stacktrace)
+    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+    stacktrace
   end
 
   defp ignore?(type: type, message: message) do


### PR DESCRIPTION
When `Airbrake.report/2` generates its own stacktrace, we were getting a tuple instead of a stacktrace (which is a list of maps).

Issue #14 has the excruciating details.  The diff on this PR is probably _much_ more instructive.

I don't plan on releasing this immediately since I'd like to also get Issue #13 done in the next day or two.

Closes #14.