### PR TITLE
Issue 13 :: derive Jason.Encoder

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
+  import_deps: [:stream_data],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 120
 ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,37 @@ jobs:
       - run: mix deps.get
       - run: mix test
 
+  poison_only_test:
+    runs-on: ubuntu-latest
+    name: Test - poison only, no jason
+    defaults:
+      run:
+        working-directory: integration_test_apps/poison_only_app
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '23'
+          elixir-version: '1.11'
+      - run: mix deps.get
+      - run: mix test
+
+  jason_only_test:
+    runs-on: ubuntu-latest
+    name: Test - jason only, no poison
+    defaults:
+      run:
+        working-directory: integration_test_apps/jason_only_app
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '23'
+          elixir-version: '1.11'
+      - run: mix deps.get
+      - run: mix test
+
+
   all_tests:
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+  * [Airbrake.Payload] Conditionally derive `Jason.Encoder` if `Jason.Encoder` is defined (i.e., `jason` is a dependency).
+  * [Airbrake.Payload] Add fields `context`, `environment`, `params`, and `session` to `Airbrake.Payload`.
   * [Airbrake.Worker] Generate a useable stacktrace when one isn't provided in the options.
 
 ## v0.9.0 (2021-06-04)

--- a/README.md
+++ b/README.md
@@ -176,3 +176,9 @@ By name:
 ```elixir
 Airbrake.monitor(Registered.Process.Name)
 ```
+
+## Integration Apps
+
+The Elixir apps defined in `integration_test_apps` are used for testing
+different dependency scenarios.  If you make changes to the way `jason` or
+`poison` is used this library, you should consider adding tests to those apps.

--- a/integration_test_apps/jason_only_app/.formatter.exs
+++ b/integration_test_apps/jason_only_app/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/integration_test_apps/jason_only_app/.gitignore
+++ b/integration_test_apps/jason_only_app/.gitignore
@@ -1,0 +1,27 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+jason_only_app-*.tar
+
+
+# Temporary files for e.g. tests
+/tmp

--- a/integration_test_apps/jason_only_app/README.md
+++ b/integration_test_apps/jason_only_app/README.md
@@ -1,0 +1,7 @@
+# JasonOnlyApp
+
+This app uses the `airbrake_client` app defined at the root of the git repository.
+
+The app imports `jason`, and not `poison`, to ensure two things:
+* Compiling the app without `poison` is successful.
+* Encoding with `jason` works just fine.

--- a/integration_test_apps/jason_only_app/lib/jason_only_app.ex
+++ b/integration_test_apps/jason_only_app/lib/jason_only_app.ex
@@ -1,0 +1,2 @@
+defmodule JasonOnlyApp do
+end

--- a/integration_test_apps/jason_only_app/mix.exs
+++ b/integration_test_apps/jason_only_app/mix.exs
@@ -1,0 +1,26 @@
+defmodule JasonOnlyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :jason_only_app,
+      version: "0.1.0",
+      elixir: "~> 1.11",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:airbrake_client, ">= 0.0.0", path: "../.."},
+      {:jason, ">= 1.0.0", optional: true}
+    ]
+  end
+end

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -1,0 +1,98 @@
+defmodule JasonOnlyAppTest do
+  use ExUnit.Case
+
+  alias Airbrake.Payload
+
+  test "Poison is undefined" do
+    # There is no conditional compilation for `poison`... yet.
+    refute Code.ensure_compiled(Poison) == {:module, Poison}
+  end
+
+  describe "Jason encoding" do
+    test "with minimal options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      assert %Payload{} = payload = Payload.new(exception, stacktrace)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _},
+               "environment" => nil,
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => nil,
+               "session" => nil
+             } = payload |> Jason.encode!() |> Jason.decode!()
+    end
+
+    test "with all options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      context = %{foo: 5}
+      params = %{foo: 55}
+      session = %{foo: 555}
+      env = %{foo: 5555}
+
+      assert %Payload{} =
+               payload =
+               Payload.new(exception, stacktrace,
+                 context: context,
+                 params: params,
+                 session: session,
+                 env: env
+               )
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _, "foo" => 5},
+               "environment" => %{"foo" => 5555},
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => %{"foo" => 55},
+               "session" => %{"foo" => 555}
+             } = payload |> Jason.encode!() |> Jason.decode!()
+    end
+  end
+end

--- a/integration_test_apps/jason_only_app/test/test_helper.exs
+++ b/integration_test_apps/jason_only_app/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/integration_test_apps/poison_only_app/.formatter.exs
+++ b/integration_test_apps/poison_only_app/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/integration_test_apps/poison_only_app/.gitignore
+++ b/integration_test_apps/poison_only_app/.gitignore
@@ -1,0 +1,27 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+poison_only_app-*.tar
+
+
+# Temporary files for e.g. tests
+/tmp

--- a/integration_test_apps/poison_only_app/README.md
+++ b/integration_test_apps/poison_only_app/README.md
@@ -1,0 +1,7 @@
+# PoisonOnlyApp
+
+This app uses the `airbrake_client` app defined at the root of the git repository.
+
+The app imports `poison`, and not `jason`, to ensure two things:
+* Compiling the app without `jason` is successful.
+* Encoding with `poison` works just fine.

--- a/integration_test_apps/poison_only_app/lib/poison_only_app.ex
+++ b/integration_test_apps/poison_only_app/lib/poison_only_app.ex
@@ -1,0 +1,2 @@
+defmodule PoisonOnlyApp do
+end

--- a/integration_test_apps/poison_only_app/mix.exs
+++ b/integration_test_apps/poison_only_app/mix.exs
@@ -1,0 +1,26 @@
+defmodule PoisonOnlyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :poison_only_app,
+      version: "0.1.0",
+      elixir: "~> 1.11",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:airbrake_client, ">= 0.0.0", path: "../.."},
+      {:poison, ">= 2.0.0"}
+    ]
+  end
+end

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -1,0 +1,99 @@
+defmodule PoisonOnlyAppTest do
+  use ExUnit.Case
+
+  alias Airbrake.Payload
+
+  test "Jason is undefined" do
+    # Makes sure conditional compilation for `jason` is skipped without error
+    # when `jason` is not a dependency.
+    refute Code.ensure_compiled(Jason) == {:module, Jason}
+  end
+
+  describe "Poison encoding" do
+    test "with minimal options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      assert %Payload{} = payload = Payload.new(exception, stacktrace)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _},
+               "environment" => nil,
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => nil,
+               "session" => nil
+             } = payload |> Poison.encode!() |> Poison.decode!()
+    end
+
+    test "with all options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      context = %{foo: 5}
+      params = %{foo: 55}
+      session = %{foo: 555}
+      env = %{foo: 5555}
+
+      assert %Payload{} =
+               payload =
+               Payload.new(exception, stacktrace,
+                 context: context,
+                 params: params,
+                 session: session,
+                 env: env
+               )
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _, "foo" => 5},
+               "environment" => %{"foo" => 5555},
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => %{"foo" => 55},
+               "session" => %{"foo" => 555}
+             } = payload |> Poison.encode!() |> Poison.decode!()
+    end
+  end
+end

--- a/integration_test_apps/poison_only_app/test/test_helper.exs
+++ b/integration_test_apps/poison_only_app/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -7,6 +7,9 @@ defmodule Airbrake.Payload do
     url: Airbrake.Mixfile.project()[:package][:links][:github]
   }
 
+  if Code.ensure_loaded?(Jason.Encoder),
+    do: @derive(Jason.Encoder)
+
   defstruct apiKey: nil,
             context: nil,
             environment: nil,

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -7,7 +7,13 @@ defmodule Airbrake.Payload do
     url: Airbrake.Mixfile.project()[:package][:links][:github]
   }
 
-  defstruct apiKey: nil, notifier: @notifier_info, errors: nil
+  defstruct apiKey: nil,
+            context: nil,
+            environment: nil,
+            errors: nil,
+            notifier: @notifier_info,
+            params: nil,
+            session: nil
 
   def new(exception, stacktrace, options \\ [])
 

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -15,6 +15,8 @@ defmodule Airbrake.Payload do
             params: nil,
             session: nil
 
+  alias Airbrake.Payload.Backtrace
+
   def new(exception, stacktrace, options \\ [])
 
   def new(%{__exception__: true} = exception, stacktrace, options) do
@@ -46,7 +48,7 @@ defmodule Airbrake.Payload do
     error = %{
       type: exception[:type],
       message: exception[:message],
-      backtrace: format_stacktrace(stacktrace)
+      backtrace: Backtrace.from_stacktrace(stacktrace)
     }
 
     Map.put(payload, :errors, [error])
@@ -90,52 +92,5 @@ defmodule Airbrake.Payload do
           if Enum.member?(filter_params, k), do: {k, "[FILTERED]"}, else: {k, v}
         end)
     end
-  end
-
-  defp format_stacktrace(stacktrace) do
-    Enum.map(stacktrace, fn
-      {module, function, args, []} ->
-        %{
-          file: "unknown",
-          line: 0,
-          function: "#{module}.#{function}#{format_args(args)}"
-        }
-
-      {module, function, args, [file: file, line: line_number]} ->
-        %{
-          file: file |> List.to_string(),
-          line: line_number,
-          function: "#{module}.#{function}#{format_args(args)}"
-        }
-
-      string ->
-        info = Regex.named_captures(~r/(?<app>\(.*?\))\s*(?<file>.*?):(?<line>\d+):\s*(?<function>.*)\z/, string)
-
-        if info do
-          %{
-            file: info["file"],
-            line: String.to_integer(info["line"]),
-            function: "#{info["app"]} #{info["function"]}"
-          }
-        else
-          %{
-            file: "unknown",
-            line: 0,
-            function: string
-          }
-        end
-    end)
-  end
-
-  defp format_args(args) when is_integer(args) do
-    "/#{args}"
-  end
-
-  defp format_args(args) when is_list(args) do
-    "(#{
-      args
-      |> Enum.map(&inspect(&1))
-      |> Enum.join(", ")
-    })"
   end
 end

--- a/lib/airbrake/payload/backtrace.ex
+++ b/lib/airbrake/payload/backtrace.ex
@@ -1,39 +1,46 @@
 defmodule Airbrake.Payload.Backtrace do
   @moduledoc false
 
-  def from_stacktrace(stacktrace) do
-    Enum.map(stacktrace, fn
-      {module, function, args, []} ->
-        %{
-          file: "unknown",
-          line: 0,
-          function: "#{module}.#{function}#{format_args(args)}"
-        }
+  def from_stacktrace(stacktrace),
+    do: Enum.map(stacktrace, &from_stacktrace_entry/1)
 
-      {module, function, args, [file: file, line: line_number]} ->
-        %{
-          file: file |> List.to_string(),
-          line: line_number,
-          function: "#{module}.#{function}#{format_args(args)}"
-        }
+  def from_stacktrace_entry({module, function, args, []}) do
+    %{
+      file: "unknown",
+      line: 0,
+      function: "#{format_module(module)}.#{function}#{format_args(args)}"
+    }
+  end
 
-      string ->
-        info = Regex.named_captures(~r/(?<app>\(.*?\))\s*(?<file>.*?):(?<line>\d+):\s*(?<function>.*)\z/, string)
+  def from_stacktrace_entry({module, function, args, [file: file, line: line_number]}) do
+    %{
+      file: file |> List.to_string(),
+      line: line_number,
+      function: "#{format_module(module)}.#{function}#{format_args(args)}"
+    }
+  end
 
-        if info do
-          %{
-            file: info["file"],
-            line: String.to_integer(info["line"]),
-            function: "#{info["app"]} #{info["function"]}"
-          }
-        else
-          %{
-            file: "unknown",
-            line: 0,
-            function: string
-          }
-        end
-    end)
+  def from_stacktrace_entry(string) when is_binary(string) do
+    info = Regex.named_captures(~r/(?<app>\(.*?\))\s*(?<file>.*?):(?<line>\d+):\s*(?<function>.*)\z/, string)
+
+    if info do
+      %{
+        file: info["file"],
+        line: String.to_integer(info["line"]),
+        function: "#{info["app"]} #{info["function"]}"
+      }
+    else
+      %{
+        file: "unknown",
+        line: 0,
+        function: string
+      }
+    end
+  end
+
+  def format_module(module) do
+    string = Atom.to_string(module)
+    if String.starts_with?(string, "Elixir."), do: string, else: ":#{string}"
   end
 
   defp format_args(args) when is_integer(args) do

--- a/lib/airbrake/payload/backtrace.ex
+++ b/lib/airbrake/payload/backtrace.ex
@@ -1,0 +1,50 @@
+defmodule Airbrake.Payload.Backtrace do
+  @moduledoc false
+
+  def from_stacktrace(stacktrace) do
+    Enum.map(stacktrace, fn
+      {module, function, args, []} ->
+        %{
+          file: "unknown",
+          line: 0,
+          function: "#{module}.#{function}#{format_args(args)}"
+        }
+
+      {module, function, args, [file: file, line: line_number]} ->
+        %{
+          file: file |> List.to_string(),
+          line: line_number,
+          function: "#{module}.#{function}#{format_args(args)}"
+        }
+
+      string ->
+        info = Regex.named_captures(~r/(?<app>\(.*?\))\s*(?<file>.*?):(?<line>\d+):\s*(?<function>.*)\z/, string)
+
+        if info do
+          %{
+            file: info["file"],
+            line: String.to_integer(info["line"]),
+            function: "#{info["app"]} #{info["function"]}"
+          }
+        else
+          %{
+            file: "unknown",
+            line: 0,
+            function: string
+          }
+        end
+    end)
+  end
+
+  defp format_args(args) when is_integer(args) do
+    "/#{args}"
+  end
+
+  defp format_args(args) when is_list(args) do
+    "(#{
+      args
+      |> Enum.map(&inspect(&1))
+      |> Enum.join(", ")
+    })"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,8 @@ defmodule Airbrake.Mixfile do
       {:mox, "~> 0.5", only: :test},
       {:poison, ">= 2.0.0", optional: true},
       {:ex_doc, "~> 0.19", only: [:dev, :test]},
-      {:excoveralls, "~> 0.12.0", only: :test}
+      {:excoveralls, "~> 0.12.0", only: :test},
+      {:stream_data, "~> 0.5", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule Airbrake.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.9 or ~> 1.0"},
+      {:jason, ">= 1.0.0", optional: true},
       {:mox, "~> 0.5", only: :test},
       {:poison, ">= 2.0.0", optional: true},
       {:ex_doc, "~> 0.19", only: [:dev, :test]},

--- a/test/airbrake/payload/backtrace_test.exs
+++ b/test/airbrake/payload/backtrace_test.exs
@@ -1,0 +1,101 @@
+defmodule Airbrake.Payload.BacktraceTests do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Airbrake.Payload.Backtrace
+
+  describe "from_stacktrace/1" do
+    test "turns a whole stacktrace into a backtrace" do
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:erl_eval, :do_apply, 6, [file: 'erl_eval.erl', line: 680]},
+        {:erl_eval, :try_clauses, 8, [file: 'erl_eval.erl', line: 914]},
+        {:elixir, :recur_eval, 3, [file: 'src/elixir.erl', line: 280]},
+        {:elixir, :eval_forms, 3, [file: 'src/elixir.erl', line: 265]},
+        {IEx.Evaluator, :handle_eval, 5, [file: 'lib/iex/evaluator.ex', line: 261]},
+        {IEx.Evaluator, :do_eval, 3, [file: 'lib/iex/evaluator.ex', line: 242]},
+        {IEx.Evaluator, :eval, 3, [file: 'lib/iex/evaluator.ex', line: 220]}
+      ]
+
+      assert Backtrace.from_stacktrace(stacktrace) == [
+               %{file: "unknown", function: "Elixir.Harbour.cats(3)", line: 0},
+               %{file: "erl_eval.erl", function: ":erl_eval.do_apply/6", line: 680},
+               %{file: "erl_eval.erl", function: ":erl_eval.try_clauses/8", line: 914},
+               %{file: "src/elixir.erl", function: ":elixir.recur_eval/3", line: 280},
+               %{file: "src/elixir.erl", function: ":elixir.eval_forms/3", line: 265},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.handle_eval/5", line: 261},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.do_eval/3", line: 242},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.eval/3", line: 220}
+             ]
+    end
+  end
+
+  describe "from_stacktrace_entry/1" do
+    property "formats an entry without a file or line" do
+      check all module <- atom(:alias),
+                function <- atom(:alphanumeric),
+                args <- list_of(integer()) do
+        entry = {module, function, args, []}
+
+        assert Backtrace.from_stacktrace_entry(entry) == %{
+                 file: "unknown",
+                 function: "#{module}.#{function}(#{Enum.join(args, ", ")})",
+                 line: 0
+               }
+      end
+    end
+
+    property "formats an entry with file and line options" do
+      check all module <- atom(:alias),
+                function <- atom(:alphanumeric),
+                arity <- positive_integer(),
+                file <- string(:ascii),
+                line <- positive_integer() do
+        entry_file = String.to_charlist(file)
+        entry = {module, function, arity, [file: entry_file, line: line]}
+
+        assert Backtrace.from_stacktrace_entry(entry) == %{
+                 file: file,
+                 function: "#{module}.#{function}/#{arity}",
+                 line: line
+               }
+      end
+    end
+
+    property "formats a string entry with app, file, and function information" do
+      check all app <- string(:alphanumeric, min_length: 1),
+                file <- string(:alphanumeric, min_length: 1),
+                line <- integer(1..1000),
+                function <- string(:alphanumeric, min_length: 1) do
+        entry = "(#{app}) #{file}:#{line}: #{function}"
+
+        assert Backtrace.from_stacktrace_entry(entry) == %{
+                 file: file,
+                 line: line,
+                 function: "(#{app}) #{function}"
+               }
+      end
+    end
+
+    property "format a string entry that can't be parsed" do
+      # the chance of generating a correct entry must be astronomical
+      check all entry <- string(:ascii) do
+        assert Backtrace.from_stacktrace_entry(entry) == %{
+                 file: "unknown",
+                 line: 0,
+                 function: entry
+               }
+      end
+    end
+  end
+
+  describe "format_module/1" do
+    test "formats an Elixir module, adding Elixir prefix" do
+      assert Backtrace.format_module(Airbrake.Payload) == "Elixir.Airbrake.Payload"
+    end
+
+    test "formats an erlang module, prepending a colon" do
+      assert Backtrace.format_module(:timer) == ":timer"
+    end
+  end
+end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -65,17 +65,24 @@ defmodule Airbrake.PayloadTest do
              } = Payload.new(exception, stacktrace)
     end
 
-    test "it reports the error class" do
+    test "reports the error class of an exception" do
       assert %{errors: [error]} = Payload.new(@exception, @stacktrace)
       assert "UndefinedFunctionError" == error.type
     end
 
-    test "it reports the error message" do
+    test "reports the type when explicitly specified"
+
+    test "reports the error message from an exception" do
       assert %{errors: [error]} = Payload.new(@exception, @stacktrace)
 
       assert "function Harbour.cats/1 is undefined (module Harbour is not available)" ==
                error.message
     end
+
+    test "reports the error message when explicitly specified"
+
+    # TODO: extract Airbrake.Payload.Backtrace to test stacktrace-to-backtrace separately
+    # TODO: stacktrace tests here can be done with dependency injection to replace all of the stacktrace tests with just one
 
     test "it generates correct stacktraces" do
       {exception, stacktrace} =
@@ -131,15 +138,23 @@ defmodule Airbrake.PayloadTest do
              ] = stacktrace
     end
 
-    test "it reports the notifier" do
+    test "reports the notifier" do
       assert %{name: "Airbrake Client", url: "https://github.com/CityBaseInc/airbrake_client", version: _} =
                Payload.new(@exception, @stacktrace).notifier
     end
 
-    test "it adds the context when given" do
+    test "sets a default context"
+
+    test "sets the context when given" do
       %{context: context} = Payload.new(@exception, @stacktrace, context: %{msg: "Potato#cake"})
       assert "Potato#cake" == context.msg
     end
+
+    test "sets environment (and rename) when given"
+
+    test "sets params when given"
+
+    test "sets session when given"
 
     test "it filters sensitive params" do
       Application.put_env(:airbrake_client, :filter_parameters, ["password"])
@@ -148,5 +163,15 @@ defmodule Airbrake.PayloadTest do
       assert "y" == payload.params["x"]
       Application.delete_env(:airbrake_client, :filter_parameters)
     end
+  end
+
+  describe "Poison encoding" do
+    test "with minimal options"
+    test "with all options"
+  end
+
+  describe "Jason encoding" do
+    test "with minimal options"
+    test "with all options"
   end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -155,12 +155,168 @@ defmodule Airbrake.PayloadTest do
   end
 
   describe "Poison encoding" do
-    test "with minimal options"
-    test "with all options"
+    test "with minimal options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      assert %Payload{} = payload = Payload.new(exception, stacktrace)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _},
+               "environment" => nil,
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => nil,
+               "session" => nil
+             } = payload |> Poison.encode!() |> Poison.decode!()
+    end
+
+    test "with all options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      context = %{foo: 5}
+      params = %{foo: 55}
+      session = %{foo: 555}
+      env = %{foo: 5555}
+
+      assert %Payload{} =
+               payload =
+               Payload.new(exception, stacktrace, context: context, params: params, session: session, env: env)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _, "foo" => 5},
+               "environment" => %{"foo" => 5555},
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => %{"foo" => 55},
+               "session" => %{"foo" => 555}
+             } = payload |> Poison.encode!() |> Poison.decode!()
+    end
   end
 
   describe "Jason encoding" do
-    test "with minimal options"
-    test "with all options"
+    test "with minimal options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      assert %Payload{} = payload = Payload.new(exception, stacktrace)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _},
+               "environment" => nil,
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => nil,
+               "session" => nil
+             } = payload |> Jason.encode!() |> Jason.decode!()
+    end
+
+    test "with all options" do
+      exception = [
+        type: "SomeAwfulError",
+        message: "something really bad happened"
+      ]
+
+      stacktrace = [
+        {Harbour, :cats, [3], []},
+        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+      ]
+
+      context = %{foo: 5}
+      params = %{foo: 55}
+      session = %{foo: 555}
+      env = %{foo: 5555}
+
+      assert %Payload{} =
+               payload =
+               Payload.new(exception, stacktrace, context: context, params: params, session: session, env: env)
+
+      assert %{
+               "apiKey" => nil,
+               "context" => %{"environment" => _, "hostname" => _, "foo" => 5},
+               "environment" => %{"foo" => 5555},
+               "errors" => [
+                 %{
+                   "backtrace" => [
+                     %{"file" => "unknown", "function" => "Elixir.Harbour.cats(3)", "line" => 0},
+                     %{"file" => "timer.erl", "function" => ":timer.tc/1", "line" => 166}
+                   ],
+                   "message" => "something really bad happened",
+                   "type" => "SomeAwfulError"
+                 }
+               ],
+               "notifier" => %{
+                 "name" => "Airbrake Client",
+                 "url" => "https://github.com/CityBaseInc/airbrake_client",
+                 "version" => "0.9.0"
+               },
+               "params" => %{"foo" => 55},
+               "session" => %{"foo" => 555}
+             } = payload |> Jason.encode!() |> Jason.decode!()
+    end
   end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -2,29 +2,24 @@ defmodule Airbrake.PayloadTest do
   use ExUnit.Case
   alias Airbrake.Payload
 
-  def get_problem do
-    try do
-      # If the following line is not on line 9 then tests will start failing.
-      # You've been warned!
-      apply(Harbour, :cats, [3])
-    rescue
-      exception -> [exception, __STACKTRACE__]
-    end
-  end
+  @exception %UndefinedFunctionError{
+    arity: 1,
+    function: :cats,
+    message: nil,
+    module: Harbour,
+    reason: nil
+  }
 
-  def get_payload(options \\ []) do
-    apply(Payload, :new, List.insert_at(get_problem(), -1, options))
-  end
-
-  def get_error(options \\ []) do
-    %{errors: [error]} = get_payload(options)
-    error
-  end
-
-  def get_context(options \\ []) do
-    %{context: context} = get_payload(options)
-    context
-  end
+  @stacktrace [
+    {Harbour, :cats, [3], []},
+    {:erl_eval, :do_apply, 6, [file: 'erl_eval.erl', line: 680]},
+    {:erl_eval, :try_clauses, 8, [file: 'erl_eval.erl', line: 914]},
+    {:elixir, :recur_eval, 3, [file: 'src/elixir.erl', line: 280]},
+    {:elixir, :eval_forms, 3, [file: 'src/elixir.erl', line: 265]},
+    {IEx.Evaluator, :handle_eval, 5, [file: 'lib/iex/evaluator.ex', line: 261]},
+    {IEx.Evaluator, :do_eval, 3, [file: 'lib/iex/evaluator.ex', line: 242]},
+    {IEx.Evaluator, :eval, 3, [file: 'lib/iex/evaluator.ex', line: 220]}
+  ]
 
   describe "new/2 and new/3" do
     test "generates report with a REAL exception" do
@@ -71,11 +66,15 @@ defmodule Airbrake.PayloadTest do
     end
 
     test "it reports the error class" do
-      assert "UndefinedFunctionError" == get_error().type
+      assert %{errors: [error]} = Payload.new(@exception, @stacktrace)
+      assert "UndefinedFunctionError" == error.type
     end
 
     test "it reports the error message" do
-      assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
+      assert %{errors: [error]} = Payload.new(@exception, @stacktrace)
+
+      assert "function Harbour.cats/1 is undefined (module Harbour is not available)" ==
+               error.message
     end
 
     test "it generates correct stacktraces" do
@@ -100,15 +99,19 @@ defmodule Airbrake.PayloadTest do
     end
 
     test "it generates correct stacktraces when the current file was a script" do
+      assert %Payload{errors: [error]} = Payload.new(@exception, @stacktrace)
+
+      # This is TEMPORARY.  The stacktrace to backtrace translation needs better tests.
       assert [
-               %{file: "unknown", line: 0, function: _},
-               %{
-                 file: "test/airbrake/payload_test.exs",
-                 line: 9,
-                 function: "Elixir.Airbrake.PayloadTest.get_problem/0"
-               },
-               %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
-             ] = get_error().backtrace
+               %{file: "unknown", function: "Elixir.Harbour.cats(3)", line: 0},
+               %{file: "erl_eval.erl", function: "erl_eval.do_apply/6", line: 680},
+               %{file: "erl_eval.erl", function: "erl_eval.try_clauses/8", line: 914},
+               %{file: "src/elixir.erl", function: "elixir.recur_eval/3", line: 280},
+               %{file: "src/elixir.erl", function: "elixir.eval_forms/3", line: 265},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.handle_eval/5", line: 261},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.do_eval/3", line: 242},
+               %{file: "lib/iex/evaluator.ex", function: "Elixir.IEx.Evaluator.eval/3", line: 220}
+             ] = error.backtrace
     end
 
     # NOTE: Regression test
@@ -130,17 +133,17 @@ defmodule Airbrake.PayloadTest do
 
     test "it reports the notifier" do
       assert %{name: "Airbrake Client", url: "https://github.com/CityBaseInc/airbrake_client", version: _} =
-               get_payload().notifier
+               Payload.new(@exception, @stacktrace).notifier
     end
 
     test "it adds the context when given" do
-      %{context: context} = get_payload(context: %{msg: "Potato#cake"})
+      %{context: context} = Payload.new(@exception, @stacktrace, context: %{msg: "Potato#cake"})
       assert "Potato#cake" == context.msg
     end
 
     test "it filters sensitive params" do
       Application.put_env(:airbrake_client, :filter_parameters, ["password"])
-      payload = get_payload(params: %{"password" => "top_secret", "x" => "y"})
+      payload = Payload.new(@exception, @stacktrace, params: %{"password" => "top_secret", "x" => "y"})
       assert "[FILTERED]" == payload.params["password"]
       assert "y" == payload.params["x"]
       Application.delete_env(:airbrake_client, :filter_parameters)

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -26,75 +26,81 @@ defmodule Airbrake.PayloadTest do
     context
   end
 
-  test "it adds the context when given" do
-    %{context: context} = get_payload(context: %{msg: "Potato#cake"})
-    assert "Potato#cake" == context.msg
-  end
+  describe "new/2 and new/3" do
+    test "it adds the context when given" do
+      %{context: context} = get_payload(context: %{msg: "Potato#cake"})
+      assert "Potato#cake" == context.msg
+    end
 
-  test "it generates correct stacktraces" do
-    {exception, stacktrace} =
-      try do
-        Enum.join(3, 'million')
-      rescue
-        exception -> {exception, __STACKTRACE__}
-      end
+    test "it generates correct stacktraces" do
+      {exception, stacktrace} =
+        try do
+          Enum.join(3, 'million')
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
 
-    %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
+      %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
 
-    assert [
-             %{file: "lib/enum.ex", line: _, function: _},
-             %{
-               file: "test/airbrake/payload_test.exs",
-               line: _,
-               function: "Elixir.Airbrake.PayloadTest.test it generates correct stacktraces/1"
-             }
-             | _
-           ] = stacktrace
-  end
+      assert [
+               %{file: "lib/enum.ex", line: _, function: _},
+               %{
+                 file: "test/airbrake/payload_test.exs",
+                 line: _,
+                 function: "Elixir.Airbrake.PayloadTest.test new/2 and new/3 it generates correct stacktraces/1"
+               }
+               | _
+             ] = stacktrace
+    end
 
-  test "it generates correct stacktraces when the current file was a script" do
-    assert [
-             %{file: "unknown", line: 0, function: _},
-             %{file: "test/airbrake/payload_test.exs", line: 9, function: "Elixir.Airbrake.PayloadTest.get_problem/0"},
-             %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
-           ] = get_error().backtrace
-  end
+    test "it generates correct stacktraces when the current file was a script" do
+      assert [
+               %{file: "unknown", line: 0, function: _},
+               %{
+                 file: "test/airbrake/payload_test.exs",
+                 line: 9,
+                 function: "Elixir.Airbrake.PayloadTest.get_problem/0"
+               },
+               %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
+             ] = get_error().backtrace
+    end
 
-  # NOTE: Regression test
-  test "it generates correct stacktraces when the method arguments are in place of arity" do
-    {exception, stacktrace} =
-      try do
-        apply(Foo, :bar, [:qux, 1, "foo\n"])
-      rescue
-        exception -> {exception, __STACKTRACE__}
-      end
+    # NOTE: Regression test
+    test "it generates correct stacktraces when the method arguments are in place of arity" do
+      {exception, stacktrace} =
+        try do
+          apply(Foo, :bar, [:qux, 1, "foo\n"])
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
 
-    %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
+      %{errors: [%{backtrace: stacktrace}]} = Payload.new(exception, stacktrace, [])
 
-    assert [
-             %{file: "unknown", line: 0, function: "Elixir.Foo.bar(:qux, 1, \"foo\\n\")"},
-             %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
-           ] = stacktrace
-  end
+      assert [
+               %{file: "unknown", line: 0, function: "Elixir.Foo.bar(:qux, 1, \"foo\\n\")"},
+               %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _
+             ] = stacktrace
+    end
 
-  test "it reports the error class" do
-    assert "UndefinedFunctionError" == get_error().type
-  end
+    test "it reports the error class" do
+      assert "UndefinedFunctionError" == get_error().type
+    end
 
-  test "it reports the error message" do
-    assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
-  end
+    test "it reports the error message" do
+      assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
+    end
 
-  test "it reports the notifier" do
-    assert %{name: "Airbrake Client", url: "https://github.com/CityBaseInc/airbrake_client", version: _} =
-             get_payload().notifier
-  end
+    test "it reports the notifier" do
+      assert %{name: "Airbrake Client", url: "https://github.com/CityBaseInc/airbrake_client", version: _} =
+               get_payload().notifier
+    end
 
-  test "it filters sensitive params" do
-    Application.put_env(:airbrake_client, :filter_parameters, ["password"])
-    payload = get_payload(params: %{"password" => "top_secret", "x" => "y"})
-    assert "[FILTERED]" == payload.params["password"]
-    assert "y" == payload.params["x"]
-    Application.delete_env(:airbrake_client, :filter_parameters)
+    test "it filters sensitive params" do
+      Application.put_env(:airbrake_client, :filter_parameters, ["password"])
+      payload = get_payload(params: %{"password" => "top_secret", "x" => "y"})
+      assert "[FILTERED]" == payload.params["password"]
+      assert "y" == payload.params["x"]
+      Application.delete_env(:airbrake_client, :filter_parameters)
+    end
   end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -38,14 +38,8 @@ defmodule Airbrake.PayloadTest do
                        function:
                          "Elixir.Airbrake.PayloadTest.test new/2 and new/3 generates report with a REAL exception/1",
                        line: _
-                     },
-                     %{file: "lib/ex_unit/runner.ex", function: "Elixir.ExUnit.Runner.exec_test/1", line: 391},
-                     %{file: "timer.erl", function: ":timer.tc/1", line: 166},
-                     %{
-                       file: "lib/ex_unit/runner.ex",
-                       function: "Elixir.ExUnit.Runner.-spawn_test_monitor/4-fun-1-/4",
-                       line: 342
                      }
+                     | _rest_of_backtrace
                    ],
                    message: "function Harbour.cats/1 is undefined (module Harbour is not available)",
                    type: "UndefinedFunctionError"

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -27,9 +27,12 @@ defmodule Airbrake.PayloadTest do
   end
 
   describe "new/2 and new/3" do
-    test "it adds the context when given" do
-      %{context: context} = get_payload(context: %{msg: "Potato#cake"})
-      assert "Potato#cake" == context.msg
+    test "it reports the error class" do
+      assert "UndefinedFunctionError" == get_error().type
+    end
+
+    test "it reports the error message" do
+      assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
     end
 
     test "it generates correct stacktraces" do
@@ -82,17 +85,14 @@ defmodule Airbrake.PayloadTest do
              ] = stacktrace
     end
 
-    test "it reports the error class" do
-      assert "UndefinedFunctionError" == get_error().type
-    end
-
-    test "it reports the error message" do
-      assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
-    end
-
     test "it reports the notifier" do
       assert %{name: "Airbrake Client", url: "https://github.com/CityBaseInc/airbrake_client", version: _} =
                get_payload().notifier
+    end
+
+    test "it adds the context when given" do
+      %{context: context} = get_payload(context: %{msg: "Potato#cake"})
+      assert "Potato#cake" == context.msg
     end
 
     test "it filters sensitive params" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
 ExUnit.start()
 Application.ensure_all_started(:mox)
+# this seems to be necessary for Elixir 1.10
+Application.ensure_all_started(:stream_data)


### PR DESCRIPTION
This PR fixes the `Airbrake.Payload` struct and derives `Jason.Encoder` for Airbrake.Payload`.  Closes #13.

## This Problem

Airbrake.io accepts a lot of fields in the payload for an error report.  However, `Airbrake.Payload` defined only three of them: 

https://github.com/CityBaseInc/airbrake_client/blob/6d0d16fad1abbd51ff0f6609a1f2be9411958d93/lib/airbrake/payload.ex#L10

Airbrake.io also accepts "context", "params", "session", and "environment" in the payload.  `Airbrake.Payload` adds values for those fields anyway, and `poison` was more than happy to encode them.  `jason` is more precise, and deriving the `Jason.Encoder` for `Airbrake.Payload` left those non-struct fields out.

Leaving out those fields also made it inevitable to get "field not defined on `Airbrake.Payload`" errors with recent versions of Elixir.

## The Fixes

This PR adds the missing fields to the `Airbrake.Payload` struct.
* This doesn't break `poison` at all.
* `Jason.Encoder` can be derived automatically (conditionally compiled).
* No more "field not defined" errors.

The only drawback is that if a field is not given a value, it is still included in the encoding, set to `null`.  Airbrake.io seems to ignore those fields, so `null` is not a problem for them.  It consumes a little more bandwidth, but not _that_ much.  (And devs should be encouraged to use all of the fields anyway.)

I greatly improved the testing around `Airbrake.Payload`.  I tried to keep each commit to one theme, and refactoring commits should have few (if any) test changes.

## Manual Tesing

I ran some tests, reporting "errors" into Airbrake.io.  You can see the errors I generated from my laptop (named `000045`):

* https://citybase.airbrake.io/projects/240982/groups/3026442380264171863?filters=%7B%22order%22%3A%22last_notice%22%2C%22resolved%22%3A%22false%22%2C%22context.environment%22%3A%22-2734551907716605563%22%7D&tab=overview

## More Testing

I added an `integration_test_apps` to make sure that the encodings work even when the app depends on just one app.  In particular, I wanted to make sure that deriving of `Jason.Encoder` happened only when `jason` was a dependency.

I don't expect these apps to fail, so they're probably not important to run locally all the time, but I did include them in the CI tests just in case.
