### PR TITLE
Add filter headers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## IN PROGRESS
 
+### Enhancements
+
+  * [Airbrake] Updates default URL to `https://api.airbrake.io`.
+
 ### Bug fixes
 
   * [Airbrake] Add `:filter_headers` option to filter HTTP headers included in `:environment`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for v0.x
 
-## IN PROGRESS
+## v0.9.1 (2021-06-08)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+  * [Airbrake] Add `:filter_headers` option to filter HTTP headers included in `:environment`.
   * [Airbrake.Payload] Conditionally derive `Jason.Encoder` if `Jason.Encoder` is defined (i.e., `jason` is a dependency).
   * [Airbrake.Payload] Add fields `context`, `environment`, `params`, and `session` to `Airbrake.Payload`.
   * [Airbrake.Worker] Generate a useable stacktrace when one isn't provided in the options.

--- a/README.md
+++ b/README.md
@@ -57,18 +57,19 @@ config :logger,
 Required configuration arguments:
 
   * `:api_key` - (binary) the token needed to access the [Airbrake
-    API](https://airbrake.io/docs/api/). You could find it in [User
+    API](https://airbrake.io/docs/api/). You can find it in [User
     Settings](https://airbrake.io/users/edit).
   * `:project_id` - (integer) the id of your project at Airbrake.
 
-Options configuration arguments:
+Optional configuration arguments:
 
   * `:environment` - (binary or function returning binary) the environment that
     will be attached to each reported exception.
   * `:filter_parameters` - (list of binaries) allows to filter out sensitive
     parameters such as passwords and tokens.
   * `:filter_headers` - (list of binaries) filters HTTP headers.
-  * `:host` - (binary) use it when you have an Errbit installation.
+  * `:host` - (binary) the URL of the HTTP host; defaults to
+    `https://api.airbrake.io`.
   * `:ignore` - (MapSet of binary or function returning boolean or :all) allows
     to ignore some or all exceptions.  See examples below.
   * `:options` - (keyword list or function returning keyword list) values that

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ config :airbrake_client,
   project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
   environment: Mix.env(),
   filter_parameters: ["password"],
+  filter_headers: ["authorization"],
   host: "https://api.airbrake.io" # or your Errbit host
 
 config :logger,
@@ -66,6 +67,7 @@ Options configuration arguments:
     will be attached to each reported exception.
   * `:filter_parameters` - (list of binaries) allows to filter out sensitive
     parameters such as passwords and tokens.
+  * `:filter_headers` - (list of binaries) filters HTTP headers.
   * `:host` - (binary) use it when you have an Errbit installation.
   * `:ignore` - (MapSet of binary or function returning boolean or :all) allows
     to ignore some or all exceptions.  See examples below.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,3 @@
 use Mix.Config
 
-config :airbrake_client,
-  api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
-  project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
-  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
-  private: [http_adapter: HTTPoison]
-
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,8 @@
 use Mix.Config
+
+# These settings can be used on the iex console.
+config :airbrake_client,
+  api_key: {:system, "AIRBRAKE_API_KEY"},
+  project_id: {:system, "AIRBRAKE_PROJECT_ID"},
+  host: {:system, "AIRBRAKE_HOST", "https://api.airbrake.io"},
+  private: [http_adapter: HTTPoison]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,7 @@
 use Mix.Config
 
+# Do NOT set :host here so that default host in Airbrake.Worker can be tested.
 config :airbrake_client,
+  api_key: "TESTING_API_KEY",
+  project_id: 8_675_309,
   private: [http_adapter: Airbrake.HTTPMock]

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -77,7 +77,7 @@ defmodule Airbrake.Payload do
   end
 
   defp add_env(payload, nil), do: payload
-  defp add_env(payload, env), do: Map.put(payload, :environment, env)
+  defp add_env(payload, env), do: Map.put(payload, :environment, filter_environment(env))
 
   defp add_params(payload, nil), do: payload
   defp add_params(payload, params), do: Map.put(payload, :params, filter_parameters(params))
@@ -86,14 +86,27 @@ defmodule Airbrake.Payload do
   defp add_session(payload, session), do: Map.put(payload, :session, session)
 
   defp filter_parameters(params) do
-    case Airbrake.Worker.get_env(:filter_parameters) do
-      nil ->
-        params
+    filter(params, Airbrake.Worker.get_env(:filter_parameters))
+  end
 
-      filter_params ->
-        Enum.into(params, %{}, fn {k, v} ->
-          if Enum.member?(filter_params, k), do: {k, "[FILTERED]"}, else: {k, v}
-        end)
+  defp filter(map, nil) do
+    map
+  end
+
+  defp filter(map, filtered_attributes) do
+    Enum.into(map, %{}, fn {k, v} ->
+      if Enum.member?(filtered_attributes, k), do: {k, "[FILTERED]"}, else: {k, v}
+    end)
+  end
+
+  defp filter_environment(env) do
+    case Map.get(env, "headers") do
+      nil ->
+        env
+
+      headers ->
+        filtered_headers = filter(headers, Airbrake.Worker.get_env(:filter_headers))
+        Map.put(env, "headers", filtered_headers)
     end
   end
 end

--- a/lib/airbrake/utils.ex
+++ b/lib/airbrake/utils.ex
@@ -1,0 +1,28 @@
+defmodule Airbrake.Utils do
+  @moduledoc false
+
+  @filtered_value "[FILTERED]"
+
+  # For filtering params and headers.
+  def filter(input, nil) do
+    input
+  end
+
+  def filter(map, filtered_attributes) when is_map(map) do
+    Enum.into(map, %{}, &filter_key_value(&1, filtered_attributes))
+  end
+
+  def filter(list, filtered_attributes) when is_list(list) do
+    Enum.map(list, &filter(&1, filtered_attributes))
+  end
+
+  def filter(other, _filtered_attributes) do
+    other
+  end
+
+  def filter_key_value({k, v}, filtered_attributes) do
+    if Enum.member?(filtered_attributes, k),
+      do: {k, @filtered_value},
+      else: {k, filter(v, filtered_attributes)}
+  end
+end

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -9,7 +9,7 @@ defmodule Airbrake.Worker do
 
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
-  @default_host "https://airbrake.io"
+  @default_host "https://api.airbrake.io"
   @http_adapter :airbrake_client
                 |> Application.get_env(:private, [])
                 |> Keyword.get(:http_adapter, HTTPoison)
@@ -138,7 +138,12 @@ defmodule Airbrake.Worker do
   defp process_name(pname, pid), do: "#{inspect(pname)} [#{inspect(pid)}]"
 
   defp notify_url do
-    "#{get_env(:host, @default_host)}/api/v3/projects/#{get_env(:project_id)}/notices?key=#{get_env(:api_key)}"
+    Path.join([
+      get_env(:host, @default_host),
+      "api/v3/projects",
+      :project_id |> get_env() |> to_string(),
+      "notices?key=#{get_env(:api_key)}"
+    ])
   end
 
   def get_env(key, default \\ nil) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.9.0"
+                 version: "0.9.1"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.9.0"
+                 version: "0.9.1"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -197,7 +197,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => nil,
                "session" => nil
@@ -241,7 +241,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -280,7 +280,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => nil,
                "session" => nil
@@ -324,7 +324,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.0"
+                 "version" => "0.9.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -126,6 +126,24 @@ defmodule Airbrake.PayloadTest do
       assert %Payload{environment: ^env} = Payload.new(@exception, @stacktrace, env: env)
     end
 
+    test "it filters sensitive headers in the environment" do
+      Application.put_env(:airbrake_client, :filter_headers, ["authorization"])
+
+      env = %{
+        "headers" => %{"authorization" => "Bearer JWT", "x" => "y"},
+        "httpMethod" => "POST"
+      }
+
+      assert %Payload{
+               environment: %{
+                 "headers" => %{"authorization" => "[FILTERED]", "x" => "y"},
+                 "httpMethod" => "POST"
+               }
+             } = Payload.new(@exception, @stacktrace, env: env)
+
+      Application.delete_env(:airbrake_client, :filter_headers)
+    end
+
     test "sets params when given" do
       params = %{foo: 55, bar: "qux"}
       assert %Payload{params: ^params} = Payload.new(@exception, @stacktrace, params: params)
@@ -312,22 +330,5 @@ defmodule Airbrake.PayloadTest do
                "session" => %{"foo" => 555}
              } = payload |> Jason.encode!() |> Jason.decode!()
     end
-  end
-
-  test "it filters sensitive headers in the environment" do
-    Application.put_env(:airbrake, :filter_headers, ["authorization"])
-
-    payload =
-      get_payload(
-        env: %{
-          "headers" => %{"authorization" => "Bearer JWT", "x" => "y"},
-          "httpMethod" => "POST"
-        }
-      )
-
-    assert "[FILTERED]" == payload.environment["headers"]["authorization"]
-    assert "y" == payload.environment["headers"]["x"]
-    assert "POST" == payload.environment["httpMethod"]
-    Application.delete_env(:airbrake, :filter_headers)
   end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -313,4 +313,21 @@ defmodule Airbrake.PayloadTest do
              } = payload |> Jason.encode!() |> Jason.decode!()
     end
   end
+
+  test "it filters sensitive headers in the environment" do
+    Application.put_env(:airbrake, :filter_headers, ["authorization"])
+
+    payload =
+      get_payload(
+        env: %{
+          "headers" => %{"authorization" => "Bearer JWT", "x" => "y"},
+          "httpMethod" => "POST"
+        }
+      )
+
+    assert "[FILTERED]" == payload.environment["headers"]["authorization"]
+    assert "y" == payload.environment["headers"]["x"]
+    assert "POST" == payload.environment["httpMethod"]
+    Application.delete_env(:airbrake, :filter_headers)
+  end
 end

--- a/test/airbrake/utils_test.exs
+++ b/test/airbrake/utils_test.exs
@@ -1,0 +1,44 @@
+defmodule Airbrake.UtilsTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Airbrake.Utils
+
+  @moduletag :focus
+
+  describe "filter/2" do
+    property "returns input unchanged when attribute list is nil" do
+      check all input <- term() do
+        assert Utils.filter(input, nil) == input
+      end
+    end
+
+    test "one big nested structure" do
+      input = %{
+        "foo" => "bar",
+        "baz" => %{"baz" => %{"baz" => %{"quux" => 999}}},
+        "qux" => %{
+          "x" => 5,
+          "y" => 55,
+          "z" => 555
+        },
+        "quuz" => 123,
+        "corge" => [1, 2, "three", %{"quux" => 789}]
+      }
+
+      filtered_attributes = ["qux", "quux", "quuz"]
+
+      assert Utils.filter(input, filtered_attributes) == %{
+               "foo" => "bar",
+               # filters deeply...
+               "baz" => %{"baz" => %{"baz" => %{"quux" => "[FILTERED]"}}},
+               # filters out a whole structure...
+               "qux" => "[FILTERED]",
+               # filters at the top level...
+               "quuz" => "[FILTERED]",
+               # filters deeply in a list, repeat attribute...
+               "corge" => [1, 2, "three", %{"quux" => "[FILTERED]"}]
+             }
+    end
+  end
+end


### PR DESCRIPTION
This is an old branch I had on the CityBase fork of `airbrake`.  It adds a `:filter_headers` option that will filter HTTP headers which `Airbrake.Plug` adds to the `:environment` in an error report.
