### PR TITLE
0.10.0: Log structs and filter atom keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for v0.x
 
+## v0.10.0 (2021-07-14)
+
+  * [Airbrake.Payload] Support logging structs in payload.
+  * [Airbrake.Payload] Filter atom keys from maps in payload.
+
 ## v0.9.1 (2021-06-08)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `airbrake_client` to your dependencies:
 ```elixir
 defp deps do
   [
-    {:airbrake_client, "~> 0.9"}
+    {:airbrake_client, "~> 0.10"}
   ]
 end
 ```

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/lib/airbrake/utils.ex
+++ b/lib/airbrake/utils.ex
@@ -8,6 +8,10 @@ defmodule Airbrake.Utils do
     input
   end
 
+  def filter(struct, filtered_attributes) when is_struct(struct) do
+    struct |> Map.from_struct() |> filter(filtered_attributes)
+  end
+
   def filter(map, filtered_attributes) when is_map(map) do
     Enum.into(map, %{}, &filter_key_value(&1, filtered_attributes))
   end
@@ -18,6 +22,10 @@ defmodule Airbrake.Utils do
 
   def filter(other, _filtered_attributes) do
     other
+  end
+
+  def filter_key_value({k, v}, filtered_attributes) when is_atom(k) do
+    filter_key_value({Atom.to_string(k), v}, filtered_attributes)
   end
 
   def filter_key_value({k, v}, filtered_attributes) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.9.1",
+      version: "0.10.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.9.1"
+                 version: "0.10.0"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.9.1"
+                 version: "0.10.0"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -197,7 +197,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => nil,
                "session" => nil
@@ -241,7 +241,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -280,7 +280,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => nil,
                "session" => nil
@@ -324,7 +324,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.9.1"
+                 "version" => "0.10.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/test/airbrake/utils_test.exs
+++ b/test/airbrake/utils_test.exs
@@ -6,6 +6,10 @@ defmodule Airbrake.UtilsTest do
 
   @moduletag :focus
 
+  defmodule Struct do
+    defstruct [:baz, :qux]
+  end
+
   describe "filter/2" do
     property "returns input unchanged when attribute list is nil" do
       check all input <- term() do
@@ -23,7 +27,8 @@ defmodule Airbrake.UtilsTest do
           "z" => 555
         },
         "quuz" => 123,
-        "corge" => [1, 2, "three", %{"quux" => 789}]
+        "corge" => [1, 2, "three", %{"quux" => 789}],
+        "struct" => %Struct{baz: 100, qux: 200}
       }
 
       filtered_attributes = ["qux", "quux", "quuz"]
@@ -37,7 +42,9 @@ defmodule Airbrake.UtilsTest do
                # filters at the top level...
                "quuz" => "[FILTERED]",
                # filters deeply in a list, repeat attribute...
-               "corge" => [1, 2, "three", %{"quux" => "[FILTERED]"}]
+               "corge" => [1, 2, "three", %{"quux" => "[FILTERED]"}],
+               # Filters a struct and casts atom keys to strings...
+               "struct" => %{"baz" => 100, "qux" => "[FILTERED]"}
              }
     end
   end


### PR DESCRIPTION
Adds support for logging payload structs, and for filtering their atom keys as strings.

This is to fix an error seen in production in the Airbrake plug when the conn params contain structs, as provided by open_api_spex: https://citybase.airbrake.io/projects/171836/groups/3053249366131459911/notices/3053249425095292476