### PR TITLE
export `handle_errors/2 callback as public

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   version_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
       - run: mix test
 
   poison_only_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Test - poison only, no jason
     defaults:
       run:
@@ -54,7 +54,7 @@ jobs:
       - run: mix test
 
   jason_only_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Test - jason only, no poison
     defaults:
       run:
@@ -70,7 +70,7 @@ jobs:
 
 
   all_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
     strategy:

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/lib/airbrake/payload/backtrace.ex
+++ b/lib/airbrake/payload/backtrace.ex
@@ -48,10 +48,6 @@ defmodule Airbrake.Payload.Backtrace do
   end
 
   defp format_args(args) when is_list(args) do
-    "(#{
-      args
-      |> Enum.map(&inspect(&1))
-      |> Enum.join(", ")
-    })"
+    "(#{Enum.map_join(args, ", ", &inspect(&1))})"
   end
 end

--- a/lib/airbrake/plug.ex
+++ b/lib/airbrake/plug.ex
@@ -19,7 +19,7 @@ defmodule Airbrake.Plug do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      defp handle_errors(conn, %{kind: :error, reason: exception, stack: stacktrace}) do
+      def handle_errors(conn, %{kind: :error, reason: exception, stack: stacktrace}) do
         conn = conn |> Plug.Conn.fetch_cookies() |> Plug.Conn.fetch_query_params()
         headers = Enum.into(conn.req_headers, %{})
 
@@ -45,7 +45,7 @@ defmodule Airbrake.Plug do
         )
       end
 
-      defp handle_errors(_conn, _map), do: nil
+      def handle_errors(_conn, _map), do: nil
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.10.0",
+      version: "0.11.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.10.0"
+                 version: "0.11.0"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.10.0"
+                 version: "0.11.0"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -197,7 +197,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => nil,
                "session" => nil
@@ -241,7 +241,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -280,7 +280,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => nil,
                "session" => nil
@@ -324,7 +324,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.10.0"
+                 "version" => "0.11.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -19,7 +19,7 @@ defmodule Airbrake.PayloadTest do
     test "generates report with a REAL exception" do
       {exception, stacktrace} =
         try do
-          apply(Harbour, :cats, [3])
+          Harbour.cats(3)
         rescue
           exception -> {exception, __STACKTRACE__}
         end

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -24,7 +24,7 @@ defmodule AirbrakeTest do
 
   test "it handles real errors" do
     try do
-      apply(Airbrake, :undefined_method, [])
+      Airbrake.undefined_method()
     rescue
       exception -> Airbrake.report(exception)
     end


### PR DESCRIPTION
## Description
As of [this PR](https://github.com/erlang/otp/pull/6126) newer versions of OTP add a check that modules _must_ export functions that are required by behaviours. Prior to this PR, apps that consume this library will emit dialyzer `:callback_not_exported` warnings and fail builds.