### PR TITLE
Update dependencies and actions

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -64,126 +64,153 @@
       #
       #     {Credo.Check.Design.DuplicatedCode, false}
       #
-      checks: [
-        #
-        ## Consistency Checks
-        #
-        {Credo.Check.Consistency.ExceptionNames, []},
-        {Credo.Check.Consistency.LineEndings, []},
-        {Credo.Check.Consistency.ParameterPatternMatching, []},
-        {Credo.Check.Consistency.SpaceAroundOperators, []},
-        {Credo.Check.Consistency.SpaceInParentheses, []},
-        {Credo.Check.Consistency.TabsOrSpaces, []},
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
 
-        #
-        ## Design Checks
-        #
-        # You can customize the priority of any check
-        # Priority values are: `low, normal, high, higher`
-        #
-        {Credo.Check.Design.AliasUsage,
-         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
-        # You can also customize the exit_status of each check.
-        # If you don't want TODO comments to cause `mix credo` to fail, just
-        # set this value to 0 (zero).
-        #
-        {Credo.Check.Design.TagTODO, [exit_status: 2]},
-        {Credo.Check.Design.TagFIXME, []},
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.TagFIXME, []},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
 
-        #
-        ## Readability Checks
-        #
-        {Credo.Check.Readability.AliasOrder, []},
-        {Credo.Check.Readability.FunctionNames, []},
-        {Credo.Check.Readability.LargeNumbers, []},
-        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
-        {Credo.Check.Readability.ModuleAttributeNames, []},
-        {Credo.Check.Readability.ModuleDoc, []},
-        {Credo.Check.Readability.ModuleNames, []},
-        {Credo.Check.Readability.ParenthesesInCondition, []},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
-        {Credo.Check.Readability.PredicateFunctionNames, []},
-        {Credo.Check.Readability.PreferImplicitTry, []},
-        {Credo.Check.Readability.RedundantBlankLines, []},
-        {Credo.Check.Readability.Semicolons, []},
-        {Credo.Check.Readability.SpaceAfterCommas, []},
-        {Credo.Check.Readability.StringSigils, []},
-        {Credo.Check.Readability.TrailingBlankLine, []},
-        {Credo.Check.Readability.TrailingWhiteSpace, []},
-        {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
-        {Credo.Check.Readability.VariableNames, []},
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
 
-        #
-        ## Refactoring Opportunities
-        #
-        {Credo.Check.Refactor.CondStatements, []},
-        {Credo.Check.Refactor.CyclomaticComplexity, []},
-        {Credo.Check.Refactor.FunctionArity, []},
-        {Credo.Check.Refactor.LongQuoteBlocks, []},
-        # {Credo.Check.Refactor.MapInto, []},
-        {Credo.Check.Refactor.MatchInCondition, []},
-        {Credo.Check.Refactor.NegatedConditionsInUnless, []},
-        {Credo.Check.Refactor.NegatedConditionsWithElse, []},
-        {Credo.Check.Refactor.Nesting, []},
-        {Credo.Check.Refactor.UnlessWithElse, []},
-        {Credo.Check.Refactor.WithClauses, []},
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
 
-        #
-        ## Warnings
-        #
-        {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
-        {Credo.Check.Warning.BoolOperationOnSameValues, []},
-        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
-        {Credo.Check.Warning.IExPry, []},
-        {Credo.Check.Warning.IoInspect, []},
-        # {Credo.Check.Warning.LazyLogging, []},
-        {Credo.Check.Warning.MixEnv, false},
-        {Credo.Check.Warning.OperationOnSameValues, []},
-        {Credo.Check.Warning.OperationWithConstantResult, []},
-        {Credo.Check.Warning.RaiseInsideRescue, []},
-        {Credo.Check.Warning.UnusedEnumOperation, []},
-        {Credo.Check.Warning.UnusedFileOperation, []},
-        {Credo.Check.Warning.UnusedKeywordOperation, []},
-        {Credo.Check.Warning.UnusedListOperation, []},
-        {Credo.Check.Warning.UnusedPathOperation, []},
-        {Credo.Check.Warning.UnusedRegexOperation, []},
-        {Credo.Check.Warning.UnusedStringOperation, []},
-        {Credo.Check.Warning.UnusedTupleOperation, []},
-        {Credo.Check.Warning.UnsafeExec, []},
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
 
-        #
-        # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
 
-        #
-        # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
-        #
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-        {Credo.Check.Consistency.UnusedVariableNames, false},
-        {Credo.Check.Design.DuplicatedCode, false},
-        {Credo.Check.Readability.AliasAs, false},
-        {Credo.Check.Readability.BlockPipe, false},
-        {Credo.Check.Readability.ImplTrue, false},
-        {Credo.Check.Readability.MultiAlias, false},
-        {Credo.Check.Readability.SeparateAliasRequire, false},
-        {Credo.Check.Readability.SinglePipe, false},
-        {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Readability.StrictModuleLayout, false},
-        {Credo.Check.Readability.WithCustomTaggedTuple, false},
-        {Credo.Check.Refactor.ABCSize, false},
-        {Credo.Check.Refactor.AppendSingleItem, false},
-        {Credo.Check.Refactor.DoubleBooleanNegation, false},
-        {Credo.Check.Refactor.ModuleDependencies, false},
-        {Credo.Check.Refactor.NegatedIsNil, false},
-        {Credo.Check.Refactor.PipeChainStart, false},
-        {Credo.Check.Refactor.VariableRebinding, false},
-        {Credo.Check.Warning.LeakyEnvironment, false},
-        {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Warning.UnsafeToAtom, false}
+          # {Credo.Check.Refactor.MapInto, []},
 
-        #
-        # Custom checks can be created using `mix credo.gen.check`.
-        #
-      ]
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
     }
   ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   version_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
@@ -30,7 +30,7 @@ jobs:
           - elixir: '1.12'
             otp: '24'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -45,7 +45,7 @@ jobs:
       run:
         working-directory: integration_test_apps/poison_only_app
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '26'
@@ -60,14 +60,13 @@ jobs:
       run:
         working-directory: integration_test_apps/jason_only_app
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '26'
           elixir-version: '1.15'
       - run: mix deps.get
       - run: mix test
-
 
   all_tests:
     runs-on: ubuntu-20.04
@@ -79,7 +78,7 @@ jobs:
           - elixir: '1.15.6'
             otp: '26.1.1'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup elixir
         uses: erlef/setup-beam@v1
         with:
@@ -90,7 +89,7 @@ jobs:
         run: mix deps.get
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: _build
           key: elixir-build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-${{ hashFiles('lib/**/*.ex', 'config/*.exs', 'mix.exs') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '23'
-          elixir-version: '1.11'
+          otp-version: '26'
+          elixir-version: '1.15'
       - run: mix deps.get
       - run: mix test
 
@@ -63,8 +63,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '23'
-          elixir-version: '1.11'
+          otp-version: '26'
+          elixir-version: '1.15'
       - run: mix deps.get
       - run: mix test
 
@@ -76,8 +76,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.11.4'
-            otp: '23.3.1'
+          - elixir: '1.15.6'
+            otp: '26.1.1'
     steps:
       - uses: actions/checkout@v2
       - name: Setup elixir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,29 +6,30 @@ on:
       - '*'
 
 jobs:
-  version_tests:
-    runs-on: ubuntu-latest
+  old_otp_version_tests:
+    runs-on: ubuntu-20.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
         include:
           - elixir: '1.10'
             otp: '22'
-          - elixir: '1.11'
-            otp: '22'
-          - elixir: '1.12'
-            otp: '22'
           - elixir: '1.10'
             otp: '23'
           - elixir: '1.11'
-            otp: '23'
-          - elixir: '1.12'
-            otp: '23'
-          # SKIP: Elixir 1.10, OTP 24
+            otp: '22'
           - elixir: '1.11'
-            otp: '24'
+            otp: '23'
           - elixir: '1.12'
-            otp: '24'
+            otp: '22'
+          - elixir: '1.12'
+            otp: '23'
+          - elixir: '1.13'
+            otp: '22'
+          - elixir: '1.13'
+            otp: '23'
+          - elixir: '1.14'
+            otp: '23'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
@@ -37,6 +38,48 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix test
+
+  version_tests:
+    runs-on: ubuntu-latest
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      matrix:
+        include:
+          - elixir: '1.11'
+            otp: '24'
+          - elixir: '1.12'
+            otp: '24'
+          - elixir: '1.13'
+            otp: '24'
+          - elixir: '1.13'
+            otp: '25'
+          - elixir: '1.14'
+            otp: '24'
+          - elixir: '1.14'
+            otp: '25'
+          - elixir: '1.14'
+            otp: '26'
+          - elixir: '1.15'
+            otp: '24'
+          - elixir: '1.15'
+            otp: '25'
+          - elixir: '1.15'
+            otp: '26'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - run: mix deps.get
+      - run: mix test
+
+  all_versions_tests:
+    name: "All Versions Tests"
+    needs: [old_otp_version_tests, version_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Elixir tests for many versions of Elixir and OTP have successfully completed."
 
   poison_only_test:
     runs-on: ubuntu-20.04
@@ -69,7 +112,7 @@ jobs:
       - run: mix test
 
   all_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     strategy:
@@ -92,10 +135,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: _build
-          key: elixir-build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-${{ hashFiles('lib/**/*.ex', 'config/*.exs', 'mix.exs') }}
-          restore-keys: |
-            elixir-build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-
-            elixir-build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+          key: elixir-build-v1-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-${{ hashFiles('lib/**/*.ex', 'config/*.exs', 'mix.exs') }}
 
       - name: Compile Deps
         run: mix deps.compile
@@ -117,3 +157,10 @@ jobs:
 
       - name: Run Dialyzer
         run: mix dialyzer --list-unused-filters
+
+  required_all_tests:
+    name: "Complete Elixir Tests"
+    needs: [all_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Elixir tests and static analyses completed succcessfully."

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 mix.lock
 .elixir_ls
 doc
+test/doc

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.4-otp-23
-erlang 23.3.1
+elixir 1.15.6-otp-26
+erlang 26.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog for v0.x
 
+## v1.0.0 (2023-10-12)
+
+### Enhancements
+
+  * [Airbrake.Worker] use only `Application.compile_env/3`, drop use of `Application.get_env/3`.
+  * Formatting changes.
+  * Allow version 1.X or 2.X for `httpoison`; drop support for 0.9.
+
+### Breaking Change
+
+  * Drop support for Elixir <1.10.  Use must use earlier version to compile with earlier versions of Elixir.
+
 ## v0.11.0 (2022-12-05)
 
   * [Airbrake.Plug] Exposes `handle_errors/2` as private

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # These settings can be used on the iex console.
 config :airbrake_client,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Do NOT set :host here so that default host in Airbrake.Worker can be tested.
 config :airbrake_client,

--- a/coveralls.json
+++ b/coveralls.json
@@ -4,6 +4,6 @@
     "test"
   ],
   "coverage_options": {
-    "minimum_coverage": 71
+    "minimum_coverage": 70
   }
 }

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -17,7 +17,7 @@ defmodule JasonOnlyAppTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       assert %Payload{} = payload = Payload.new(exception, stacktrace)
@@ -54,7 +54,7 @@ defmodule JasonOnlyAppTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       context = %{foo: 5}

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -18,7 +18,7 @@ defmodule PoisonOnlyAppTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       assert %Payload{} = payload = Payload.new(exception, stacktrace)
@@ -55,7 +55,7 @@ defmodule PoisonOnlyAppTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       context = %{foo: 5}

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -10,17 +10,9 @@ defmodule Airbrake.Worker do
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
   @default_host "https://api.airbrake.io"
-  # credo:disable-for-next-line Credo.Check.Warning.ApplicationConfigInModuleAttribute
-  @http_adapter (if Version.compare(System.version(), "1.10.0-dev") in [:eq, :gt] do
-                   :airbrake_client
-                   |> Application.compile_env(:private, [])
-                   |> Keyword.get(:http_adapter, HTTPoison)
-                 else
-                   # Remove this clause when Elixir 1.10+ is the minimal supported version.
-                   :airbrake_client
-                   |> Application.get_env(:private, [])
-                   |> Keyword.get(:http_adapter, HTTPoison)
-                 end)
+  @http_adapter :airbrake_client
+                |> Application.compile_env(:private, [])
+                |> Keyword.get(:http_adapter, HTTPoison)
 
   @doc """
   Send a report to Airbrake.

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Airbrake.Mixfile do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.30", only: [:dev, :test]},
       {:excoveralls, "~> 0.18", only: :test},
-      {:httpoison, "~> 0.9 or ~> 1.0"},
+      {:httpoison, "~> 1.0 or ~> 2.0"},
       {:jason, ">= 1.0.0", optional: true},
       {:mox, "~> 1.1", only: :test},
       {:poison, ">= 2.0.0", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "0.11.0",
+      version: "1.0.0",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -58,15 +58,17 @@ defmodule Airbrake.Mixfile do
 
   defp deps do
     [
-      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.19", only: [:dev, :test]},
-      {:excoveralls, "~> 0.12.0", only: :test},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      # 1.4 is not compilable with Elixir <1.12.
+      # For test CI, we just need to _compile_ dialyxir on earlier versions.
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.30", only: [:dev, :test]},
+      {:excoveralls, "~> 0.18", only: :test},
       {:httpoison, "~> 0.9 or ~> 1.0"},
       {:jason, ">= 1.0.0", optional: true},
-      {:mox, "~> 0.5", only: :test},
+      {:mox, "~> 1.1", only: :test},
       {:poison, ">= 2.0.0", optional: true},
-      {:stream_data, "~> 0.5", only: [:dev, :test]}
+      {:stream_data, "~> 0.6", only: [:dev, :test]}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -79,6 +79,7 @@ defmodule Airbrake.Mixfile do
         "compile --force --warnings-as-errors",
         "credo --strict",
         "format --check-formatted",
+        "docs --output test/doc",
         "coveralls --raise",
         "dialyzer"
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Airbrake.Mixfile do
     [
       app: :airbrake_client,
       version: "0.11.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       aliases: aliases(),

--- a/test/airbrake/payload/backtrace_test.exs
+++ b/test/airbrake/payload/backtrace_test.exs
@@ -8,13 +8,13 @@ defmodule Airbrake.Payload.BacktraceTests do
     test "turns a whole stacktrace into a backtrace" do
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:erl_eval, :do_apply, 6, [file: 'erl_eval.erl', line: 680]},
-        {:erl_eval, :try_clauses, 8, [file: 'erl_eval.erl', line: 914]},
-        {:elixir, :recur_eval, 3, [file: 'src/elixir.erl', line: 280]},
-        {:elixir, :eval_forms, 3, [file: 'src/elixir.erl', line: 265]},
-        {IEx.Evaluator, :handle_eval, 5, [file: 'lib/iex/evaluator.ex', line: 261]},
-        {IEx.Evaluator, :do_eval, 3, [file: 'lib/iex/evaluator.ex', line: 242]},
-        {IEx.Evaluator, :eval, 3, [file: 'lib/iex/evaluator.ex', line: 220]}
+        {:erl_eval, :do_apply, 6, [file: ~c"erl_eval.erl", line: 680]},
+        {:erl_eval, :try_clauses, 8, [file: ~c"erl_eval.erl", line: 914]},
+        {:elixir, :recur_eval, 3, [file: ~c"src/elixir.erl", line: 280]},
+        {:elixir, :eval_forms, 3, [file: ~c"src/elixir.erl", line: 265]},
+        {IEx.Evaluator, :handle_eval, 5, [file: ~c"lib/iex/evaluator.ex", line: 261]},
+        {IEx.Evaluator, :do_eval, 3, [file: ~c"lib/iex/evaluator.ex", line: 242]},
+        {IEx.Evaluator, :eval, 3, [file: ~c"lib/iex/evaluator.ex", line: 220]}
       ]
 
       assert Backtrace.from_stacktrace(stacktrace) == [

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -12,7 +12,7 @@ defmodule Airbrake.PayloadTest do
 
   @stacktrace [
     {Harbour, :cats, [3], []},
-    {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+    {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
   ]
 
   describe "new/2 and new/3" do
@@ -89,7 +89,7 @@ defmodule Airbrake.PayloadTest do
     test "it generates correct stacktraces when the current file was a script" do
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       assert %Payload{errors: [error]} = Payload.new(@exception, stacktrace)
@@ -175,7 +175,7 @@ defmodule Airbrake.PayloadTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       assert %Payload{} = payload = Payload.new(exception, stacktrace)
@@ -212,7 +212,7 @@ defmodule Airbrake.PayloadTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       context = %{foo: 5}
@@ -258,7 +258,7 @@ defmodule Airbrake.PayloadTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       assert %Payload{} = payload = Payload.new(exception, stacktrace)
@@ -295,7 +295,7 @@ defmodule Airbrake.PayloadTest do
 
       stacktrace = [
         {Harbour, :cats, [3], []},
-        {:timer, :tc, 1, [file: 'timer.erl', line: 166]}
+        {:timer, :tc, 1, [file: ~c"timer.erl", line: 166]}
       ]
 
       context = %{foo: 5}

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.11.0"
+                 version: "1.0.0"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "0.11.0"
+                 version: "1.0.0"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -197,7 +197,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => nil,
                "session" => nil
@@ -241,7 +241,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -280,7 +280,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => nil,
                "session" => nil
@@ -324,7 +324,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "0.11.0"
+                 "version" => "1.0.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -13,7 +13,7 @@ defmodule Airbrake.WorkerTest do
 
     {exception, stacktrace} =
       try do
-        Enum.join(3, 'million')
+        Enum.join(3, ~c"million")
       rescue
         exception -> {exception, __STACKTRACE__}
       end


### PR DESCRIPTION
This PR updates dependencies, in particular allowing for `httpoison` version 2.

* Minimum versions for dev/test dependency are bumped (e.g., `mox`, `credo`, `dialyxir`, etc.).
* New `.credo.exs` is generated.
* Elixir/OTP version matrix is updated in test CI.

This PR also bumps the the _major_ version to 1.0.0:
* Breaking change: we no longer support Elixir <1.10 (because of `Application.compile_env/3`).
* Maturity: we've been using this library for over five years.
