### PR TITLE
Set session from Logger metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for v0.x
 
+## v2.1.0 (??????????)
+
+### Enhancements
+
+  * New config option: if `:session` is set to `:include_logger_metadata`, the
+    Logger metadata from `Logger.metadata/0` is added to the `session` field of
+    the report.  (If the option is not set, the metadata is not included.)
+
 ## v2.0.0 (2024-03-11)
 
 ### Enhancements
@@ -10,7 +18,7 @@
 ### Breaking Change
 
   * Drop support for Elixir <1.12
-    
+
 ## v1.0.0 (2023-10-12)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ config :airbrake_client,
   environment: Mix.env(),
   filter_parameters: ["password"],
   filter_headers: ["authorization"],
+  session: :include_logger_metadata,
   host: "https://api.airbrake.io" # or your Errbit host
 
 config :logger,
   backends: [{Airbrake.LoggerBackend, :error}, :console]
 ```
+
+Split this config across your `config/*.exs` files (especially the runtime
+setting in `config/runtime.exs`).
 
 Required configuration arguments:
 
@@ -74,6 +78,24 @@ Optional configuration arguments:
     to ignore some or all exceptions.  See examples below.
   * `:options` - (keyword list or function returning keyword list) values that
     are included in all reports to Airbrake.io.  See examples below.
+  * `:session` - can be set to `:include_logger_metadata` to include Logger
+    metadata in the `session` field of the report; omit this option if you do
+    not want Logger metadata.  See below for more information.
+
+### Logger metadata in the `session`
+
+If you set the `:session` config to `:include_logger_metadata`, the Logger
+metadata from the process that invokes `Airbrake.report/2` will be the initial
+session data for the `session` field.  The values passed as `:session` in the
+`options` parameter of `Airbrake.report/2` are _added_ to the session value,
+overwriting any Logger metadata values.
+
+If you do not set the `:session` config, only the `:session` value passed as the
+options to `Airbrake.report/2` will be used for the `session` field in the
+report.
+
+If the `session` turns out to be empty (for whatever reason), it is instead set
+to `nil` (and should not show up in the report).
 
 ### Ignoring some exceptions
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,7 @@
 import Config
 
 # These settings can be used on the iex console.
+# More are set in `config/runtime.exs`.
 config :airbrake_client,
-  api_key: {:system, "AIRBRAKE_API_KEY"},
-  project_id: {:system, "AIRBRAKE_PROJECT_ID"},
-  host: {:system, "AIRBRAKE_HOST", "https://api.airbrake.io"},
+  session: :include_logger_metadata,
   private: [http_adapter: HTTPoison]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,15 @@
+import Config
+
+case config_env() do
+  :dev ->
+    config :airbrake_client,
+      api_key: System.get_env("AIRBRAKE_API_KEY"),
+      project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
+      host: System.get_env("AIRBRAKE_HOST", "https://api.airbrake.io")
+
+  :test ->
+    nil
+
+  :prod ->
+    nil
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,5 @@ import Config
 config :airbrake_client,
   api_key: "TESTING_API_KEY",
   project_id: 8_675_309,
-  private: [http_adapter: Airbrake.HTTPMock]
+  private: [http_adapter: Airbrake.HTTPMock],
+  filter_parameters: ["password"]

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/lib/airbrake/config.ex
+++ b/lib/airbrake/config.ex
@@ -1,0 +1,47 @@
+defmodule Airbrake.Config do
+  @moduledoc false
+
+  defmodule Behaviour do
+    @moduledoc false
+
+    @callback get(atom()) :: any()
+
+    @callback get(atom(), any()) :: any()
+
+    @callback env :: String.t()
+
+    @callback hostname :: String.t()
+  end
+
+  @behaviour Airbrake.Config.Behaviour
+
+  # Gets a value from the `:airbrake_client` config.
+  @impl Airbrake.Config.Behaviour
+  def get(key, default \\ nil) do
+    :airbrake_client
+    |> Application.get_env(key, default)
+    |> resolve()
+  end
+
+  # Returns the name of the environment.
+  @impl Airbrake.Config.Behaviour
+  def env do
+    case Application.get_env(:airbrake_client, :environment) do
+      nil -> hostname()
+      {:system, var} -> System.get_env(var, hostname())
+      atom_env when is_atom(atom_env) -> to_string(atom_env)
+      str_env when is_binary(str_env) -> str_env
+      fun_env when is_function(fun_env) -> fun_env.()
+    end
+  end
+
+  # Returns a hostname.
+  @impl Airbrake.Config.Behaviour
+  def hostname do
+    System.get_env("HOST") || to_string(elem(:inet.gethostname(), 1))
+  end
+
+  defp resolve({:system, key, default}), do: System.get_env(key) || default
+  defp resolve({:system, key}), do: System.get_env(key)
+  defp resolve(value), do: value
+end

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -91,6 +91,6 @@ defmodule Airbrake.Payload do
   end
 
   defp filter(map, attributes_key) do
-    Utils.filter(map, Airbrake.Worker.get_env(attributes_key))
+    Utils.filter(map, Airbrake.Worker.get_config(attributes_key))
   end
 end

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -1,6 +1,8 @@
 defmodule Airbrake.Payload do
   @moduledoc false
 
+  alias Airbrake.Config
+
   @notifier_info %{
     name: "Airbrake Client",
     version: Airbrake.Mixfile.project()[:version],
@@ -47,7 +49,7 @@ defmodule Airbrake.Payload do
 
   defp build(:context, options) do
     Map.merge(
-      %{environment: env(), hostname: hostname()},
+      %{environment: Config.env(), hostname: Config.hostname()},
       Keyword.get(options, :context, %{})
     )
   end
@@ -64,20 +66,6 @@ defmodule Airbrake.Payload do
     Keyword.get(options, key)
   end
 
-  defp env do
-    case Application.get_env(:airbrake_client, :environment) do
-      nil -> hostname()
-      {:system, var} -> System.get_env(var) || hostname()
-      atom_env when is_atom(atom_env) -> to_string(atom_env)
-      str_env when is_binary(str_env) -> str_env
-      fun_env when is_function(fun_env) -> fun_env.()
-    end
-  end
-
-  def hostname do
-    System.get_env("HOST") || to_string(elem(:inet.gethostname(), 1))
-  end
-
   defp filter_parameters(params), do: filter(params, :filter_parameters)
 
   defp filter_environment(nil) do
@@ -90,7 +78,7 @@ defmodule Airbrake.Payload do
       else: env
   end
 
-  defp filter(map, attributes_key) do
-    Utils.filter(map, Airbrake.Worker.get_config(attributes_key))
+  defp filter(map, config_key) do
+    Utils.filter(map, Config.get(config_key))
   end
 end

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -30,15 +30,11 @@ defmodule Airbrake.Payload do
   def new(exception, stacktrace, options) when is_list(exception) do
     %__MODULE__{
       errors: [build_error(exception, stacktrace)],
-      context: Map.merge(%{environment: env(), hostname: hostname()}, get_option(options, :context) || %{}),
-      environment: options |> get_option(:env) |> filter_environment(),
-      params: options |> get_option(:params) |> filter_parameters(),
-      session: get_option(options, :session)
+      context: build(:context, options),
+      environment: build(:environment, options),
+      params: build(:params, options),
+      session: build(:session, options)
     }
-  end
-
-  defp get_option(options, key) do
-    Keyword.get(options, key)
   end
 
   defp build_error(exception, stacktrace) do
@@ -47,6 +43,25 @@ defmodule Airbrake.Payload do
       message: exception[:message],
       backtrace: Backtrace.from_stacktrace(stacktrace)
     }
+  end
+
+  defp build(:context, options) do
+    Map.merge(
+      %{environment: env(), hostname: hostname()},
+      Keyword.get(options, :context, %{})
+    )
+  end
+
+  defp build(:environment, options) do
+    options |> Keyword.get(:env) |> filter_environment()
+  end
+
+  defp build(:params, options) do
+    options |> Keyword.get(:params) |> filter_parameters()
+  end
+
+  defp build(key, options) do
+    Keyword.get(options, key)
   end
 
   defp env do

--- a/lib/airbrake/payload/builder.ex
+++ b/lib/airbrake/payload/builder.ex
@@ -1,0 +1,76 @@
+defmodule Airbrake.Payload.Builder do
+  @moduledoc false
+
+  alias Airbrake.Payload.Backtrace
+  alias Airbrake.Utils
+
+  def build_error(exception, stacktrace) do
+    %{
+      type: exception[:type],
+      message: exception[:message],
+      backtrace: Backtrace.from_stacktrace(stacktrace)
+    }
+  end
+
+  def build(:context, opts) do
+    config = get_config(opts)
+
+    Map.merge(
+      %{environment: config.env(), hostname: config.hostname()},
+      opts |> Keyword.get(:context, %{}) |> Enum.into(%{})
+    )
+  end
+
+  def build(:environment, opts) do
+    environment =
+      Keyword.get_lazy(opts, :environment, fn ->
+        Keyword.get(opts, :env)
+      end)
+
+    case environment do
+      nil -> nil
+      env -> env |> Enum.into(%{}) |> filter_environment(opts)
+    end
+  end
+
+  def build(:params, opts) do
+    case Keyword.get(opts, :params) do
+      nil -> nil
+      params -> params |> Enum.into(%{}) |> filter_parameters(opts)
+    end
+  end
+
+  def build(:session, opts) do
+    if Keyword.has_key?(opts, :session),
+      do: opts |> Keyword.get(:session) |> Enum.into(%{}),
+      else: nil
+  end
+
+  def filter_parameters(params, opts) do
+    filter_parameters = get_config(opts).get(:filter_parameters, [])
+
+    Utils.filter(params, filter_parameters)
+  end
+
+  def filter_environment(nil) do
+    nil
+  end
+
+  def filter_environment(environment, opts) do
+    filter_headers = get_config(opts).get(:filter_headers, [])
+
+    cond do
+      Map.has_key?(environment, "headers") ->
+        Map.update!(environment, "headers", &Utils.filter(&1, filter_headers))
+
+      Map.has_key?(environment, :headers) ->
+        Map.update!(environment, :headers, &Utils.filter(&1, filter_headers))
+
+      true ->
+        environment
+    end
+  end
+
+  defp get_config(opts),
+    do: Keyword.get(opts, :config, Airbrake.Config)
+end

--- a/lib/airbrake/payload/builder.ex
+++ b/lib/airbrake/payload/builder.ex
@@ -41,9 +41,19 @@ defmodule Airbrake.Payload.Builder do
   end
 
   def build(:session, opts) do
-    if Keyword.has_key?(opts, :session),
-      do: opts |> Keyword.get(:session) |> Enum.into(%{}),
-      else: nil
+    config = get_config(opts)
+
+    logger_metadata =
+      if config.get(:session) == :include_logger_metadata,
+        do: Keyword.get(opts, :logger_metadata, []),
+        else: []
+
+    opts_session = opts |> Keyword.get(:session, %{}) |> Enum.into(%{})
+    full_session = logger_metadata |> Enum.into(%{}) |> Map.merge(opts_session)
+
+    if full_session == %{},
+      do: nil,
+      else: full_session
   end
 
   def filter_parameters(params, opts) do

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -108,7 +108,7 @@ defmodule Airbrake.Worker do
   end
 
   defp build_options(current_options) do
-    case get_env(:options) do
+    case get_config(:options) do
       {mod, fun, 1} ->
         apply(mod, fun, [current_options])
 
@@ -126,7 +126,7 @@ defmodule Airbrake.Worker do
   end
 
   defp ignore?(type: type, message: message) do
-    ignore?(get_env(:ignore), type, message)
+    ignore?(get_config(:ignore), type, message)
   end
 
   defp ignore?(nil, _type, _message), do: false
@@ -139,20 +139,20 @@ defmodule Airbrake.Worker do
 
   defp notify_url do
     Path.join([
-      get_env(:host, @default_host),
+      get_config(:host, @default_host),
       "api/v3/projects",
-      :project_id |> get_env() |> to_string(),
-      "notices?key=#{get_env(:api_key)}"
+      :project_id |> get_config() |> to_string(),
+      "notices?key=#{get_config(:api_key)}"
     ])
   end
 
-  def get_env(key, default \\ nil) do
+  def get_config(key, default \\ nil) do
     :airbrake_client
     |> Application.get_env(key, default)
-    |> process_env()
+    |> process_config()
   end
 
-  defp process_env({:system, key, default}), do: System.get_env(key) || default
-  defp process_env({:system, key}), do: System.get_env(key)
-  defp process_env(value), do: value
+  defp process_config({:system, key, default}), do: System.get_env(key) || default
+  defp process_config({:system, key}), do: System.get_env(key)
+  defp process_config(value), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "2.0.0",
+      version: "2.1.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -59,9 +59,7 @@ defmodule Airbrake.Mixfile do
   defp deps do
     [
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      # 1.4 is not compilable with Elixir <1.12.
-      # For test CI, we just need to _compile_ dialyxir on earlier versions.
-      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.30", only: [:dev, :test]},
       {:excoveralls, "~> 0.18", only: :test},
       {:httpoison, "~> 1.0 or ~> 2.0"},

--- a/test/airbrake/payload/builder_test.exs
+++ b/test/airbrake/payload/builder_test.exs
@@ -1,0 +1,229 @@
+defmodule Airbrake.Payload.BuilderTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import Mox
+
+  alias Airbrake.Payload.Builder
+
+  setup :verify_on_exit!
+
+  describe "build/1 :context" do
+    property "builds default/initial context using env and hostname from config" do
+      opts = [config: MockConfig]
+
+      check all env <- env(),
+                hostname <- hostname() do
+        MockConfig
+        |> stub(:env, fn -> env end)
+        |> stub(:hostname, fn -> hostname end)
+
+        assert Builder.build(:context, opts) == %{environment: env, hostname: hostname}
+      end
+    end
+
+    property "can add more context" do
+      check all env <- env(),
+                hostname <- hostname(),
+                foo <- one_of([integer(), string(:alphanumeric)]),
+                bar <- one_of([integer(), string(:alphanumeric)]) do
+        MockConfig
+        |> stub(:env, fn -> env end)
+        |> stub(:hostname, fn -> hostname end)
+
+        opts = [
+          config: MockConfig,
+          context: %{foo: foo, bar: bar}
+        ]
+
+        assert Builder.build(:context, opts) == %{
+                 environment: env,
+                 hostname: hostname,
+                 foo: foo,
+                 bar: bar
+               }
+      end
+    end
+
+    property "can add more context with keyword list" do
+      check all env <- env(),
+                hostname <- hostname(),
+                foo <- one_of([integer(), string(:alphanumeric)]),
+                bar <- one_of([integer(), string(:alphanumeric)]) do
+        MockConfig
+        |> stub(:env, fn -> env end)
+        |> stub(:hostname, fn -> hostname end)
+
+        opts = [
+          config: MockConfig,
+          context: [foo: foo, bar: bar]
+        ]
+
+        assert Builder.build(:context, opts) == %{
+                 environment: env,
+                 hostname: hostname,
+                 foo: foo,
+                 bar: bar
+               }
+      end
+    end
+
+    property "context in opts overwrites defaults" do
+      check all env <- env(),
+                hostname <- hostname(),
+                opts_env <- env(),
+                opts_hostname <- hostname(),
+                foo <- integer() do
+        MockConfig
+        |> stub(:env, fn -> env end)
+        |> stub(:hostname, fn -> hostname end)
+
+        opts = [
+          config: MockConfig,
+          context: %{foo: foo, environment: opts_env, hostname: opts_hostname}
+        ]
+
+        assert Builder.build(:context, opts) == %{
+                 environment: opts_env,
+                 hostname: opts_hostname,
+                 foo: foo
+               }
+      end
+    end
+  end
+
+  describe "build/1 :environment" do
+    test "returns nil if unspecified" do
+      opts = []
+
+      assert is_nil(Builder.build(:environment, opts))
+    end
+
+    property "returns value from opts" do
+      check all environment <- map_of(atom(:alphanumeric), string(:alphanumeric)) do
+        opts = [
+          environment: environment
+        ]
+
+        assert Builder.build(:environment, opts) == environment
+      end
+    end
+
+    property "can specify with deprecated :env key" do
+      check all environment <- map_of(atom(:alphanumeric), string(:alphanumeric)) do
+        opts = [
+          env: environment
+        ]
+
+        assert Builder.build(:environment, opts) == environment
+      end
+    end
+
+    property "returns keyword list from opts as map" do
+      check all environment <- keyword_of(string(:alphanumeric)) do
+        opts = [
+          environment: environment
+        ]
+
+        assert Builder.build(:environment, opts) == Map.new(environment)
+      end
+    end
+
+    property "filters headers" do
+      check all headers1 <- map_of(string_key(), string(:alphanumeric)),
+                headers2 <- map_of(string_key(), string(:alphanumeric)),
+                headers = Map.merge(headers1, headers2) do
+        # filter keys in headers1
+        stub(MockConfig, :get, fn :filter_headers, _ -> Map.keys(headers1) end)
+
+        opts = [
+          config: MockConfig,
+          environment: %{headers: headers}
+        ]
+
+        assert %{headers: filtered_headers} = Builder.build(:environment, opts)
+
+        assert filtered_headers
+               |> Map.take(Map.keys(headers1))
+               |> Map.values()
+               |> Enum.all?(&(&1 == "[FILTERED]"))
+
+        assert filtered_headers |> Map.take(Map.keys(headers2)) |> Enum.all?(fn {k, v} -> v == Map.get(headers, k) end)
+      end
+    end
+  end
+
+  describe "build/1 :params" do
+    test "returns nil if unspecified" do
+      opts = []
+
+      assert is_nil(Builder.build(:params, opts))
+    end
+
+    property "returns value from opts" do
+      check all params <- map_of(string_key(), string(:alphanumeric)) do
+        opts = [
+          params: params
+        ]
+
+        assert Builder.build(:params, opts) == params
+      end
+    end
+
+    property "filters params" do
+      # NOTE: this does NOT test nested filtering.
+      # That's tested with the Util function.
+
+      check all params1 <- map_of(string_key(), string(:alphanumeric)),
+                params2 <- map_of(string_key(), string(:alphanumeric)),
+                params = Map.merge(params1, params2) do
+        # filter keys in params1
+        stub(MockConfig, :get, fn :filter_parameters, _ -> Map.keys(params1) end)
+
+        opts = [
+          config: MockConfig,
+          params: params
+        ]
+
+        assert %{} = filtered_params = Builder.build(:params, opts)
+
+        assert filtered_params
+               |> Map.take(Map.keys(params1))
+               |> Map.values()
+               |> Enum.all?(&(&1 == "[FILTERED]"))
+
+        assert filtered_params |> Map.take(Map.keys(params2)) |> Enum.all?(fn {k, v} -> v == Map.get(params, k) end)
+      end
+    end
+  end
+
+  describe "build/1 :session" do
+    test "nil by default" do
+      opts = []
+
+      assert is_nil(Builder.build(:session, opts))
+    end
+
+    property "returns value from opts" do
+      check all session <- map_of(string_key(), string(:alphanumeric)) do
+        opts = [
+          session: session
+        ]
+
+        assert Builder.build(:session, opts) == session
+      end
+    end
+  end
+
+  defp string_key do
+    string(:alphanumeric, min_length: 3)
+  end
+
+  defp env do
+    member_of(["dev", "uat", "staging", "prod"])
+  end
+
+  defp hostname do
+    string(:alphanumeric, min_length: 3)
+  end
+end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "2.0.0"
+                 version: "2.1.0"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "2.0.0"
+                 version: "2.1.0"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -198,7 +198,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => nil,
                "session" => nil
@@ -242,7 +242,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -281,7 +281,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => nil,
                "session" => nil
@@ -325,7 +325,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.0.0"
+                 "version" => "2.1.0"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -146,18 +146,19 @@ defmodule Airbrake.PayloadTest do
 
     test "sets params when given" do
       params = %{foo: 55, bar: "qux"}
-      assert %Payload{params: ^params} = Payload.new(@exception, @stacktrace, params: params)
+
+      assert %Payload{
+               params: %{"foo" => 55, "bar" => "qux"}
+             } = Payload.new(@exception, @stacktrace, params: params)
     end
 
     test "filters sensitive params" do
-      Application.put_env(:airbrake_client, :filter_parameters, ["password"])
-
+      # "password" is filtered out in `config/test.exs`
+      # Filtering is tested in more depth for `Airbrake.Payload.Builder`.
       params = %{"password" => "top_secret", "x" => "y"}
 
       assert %Payload{params: %{"password" => "[FILTERED]", "x" => "y"}} =
                Payload.new(@exception, @stacktrace, params: params)
-
-      Application.delete_env(:airbrake_client, :filter_parameters)
     end
 
     test "sets session when given" do

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,1 +1,2 @@
 Mox.defmock(Airbrake.HTTPMock, for: HTTPoison.Base)
+Mox.defmock(MockConfig, for: Airbrake.Config.Behaviour)


### PR DESCRIPTION
## Description

The basic use case we wanted to solve was to add a `request_id` in an Airbrake report.  This makes the most sense in the `session` field for the report.  We also realized that we're storing the `request_id` in the Logger metadata, and we're storing a lot of useful information in the Logger metadata.  Let's face it: if it's in the Logger metadata, it's good for debugging.  So it seems natural to also include it in an Airbrake report.

Adding Logger metadata to the session is optional.  You need to set `session: :include_logger_metadata` in the `:airbrake_client` config.

All values from `Logger.metadata()` are added to the `session` field.  The map for `:session` in the `opts` passed to a `report/?` function overrides the Logger metadata.

## Testing

I used this code to manually test:

```elixir
defmodule ReportTest do
  def send do
    Logger.metadata(foo: 5, bar: "yes!")

    Airbrake.report(
      [type: "AirbrakeClientTester", message: "testing Airbrake.report/2 with maximal options"],
      context: %{foo: 5},
      params: %{foo: 55},
      session: %{foo: 555},
      env: %{foo: 5555}
    ) |> IO.inspect()
  end
end

ReportTest.send()
```

Ran it like this: `mix compile && iex -S mix run manual_test.exs`

Screenshots:

![Screenshot 2024-04-01 at 1 38 06 PM](https://github.com/CityBaseInc/airbrake_client/assets/6766/473fac8f-378b-4d15-9aa5-8990b9a23ad4)

![Screenshot 2024-04-01 at 1 38 37 PM](https://github.com/CityBaseInc/airbrake_client/assets/6766/c668978c-43a3-42d8-8195-863945614fbb)
