### PR TITLE
Production aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for v0.x
 
+## IN PROGRESS
+
+### Enhancements
+
+* Better config name: `:context_environment` replaces `:environment` in the
+  configuration.  `:environment` will continue to work for backwards compatibility.
+* New config option: `:production_aliases` can be set to a list of names that
+  should be translated to `"production"` for `notice.context.environment`.  See
+  README for more details.
+
 ## v2.1.0 (??????????)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 config :airbrake_client,
   api_key: System.get_env("AIRBRAKE_API_KEY"),
   project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
-  environment: System.get_env("KUBERNETES_CLUSTER"),
+  context_environment: System.get_env("KUBERNETES_CLUSTER"),
   filter_parameters: ["password"],
   filter_headers: ["authorization"],
   session: :include_logger_metadata,
@@ -51,9 +51,10 @@ Required configuration arguments:
 
 Optional configuration arguments:
 
-  * `:environment` - (binary or function returning binary) the deployment
-    environment; used to set `notice.context.environment`.  See the "Setting the
-    environment" section below.
+  * `:context_environment` - (binary or function returning binary) the
+    deployment environment; used to set `notice.context.environment`.  See the
+    "Setting the environment in the context" section below.
+    * This was formerly `:environment`, and this can still be used.
   * `:filter_parameters` - (list of strings) filters parameters that may map to
     sensitive data such as passwords and tokens.
   * `:filter_headers` - (list of strings) filters HTTP headers.
@@ -70,7 +71,7 @@ Optional configuration arguments:
   * `:options` - (keyword list or function returning keyword list) values that
     are included in all reports to Airbrake.io.  See examples below.
   * `:production_aliases` - (list of strings) a list of `"production"` aliases.
-    See the "Setting the environment" section below.
+    See the "Setting the environment in the context" section below.
   * `:session` - can be set to `:include_logger_metadata` to include Logger
     metadata in the `session` field of the report; omit this option if you do
     not want Logger metadata.  See below for more information.
@@ -79,18 +80,18 @@ See the ["Create notice
 v3"](https://docs.airbrake.io/docs/devops-tools/api/#create-notice-v3) section
 in the Airbrake API docs to understand some of these options better.
 
-### Setting the environment
+### Setting the environment in the context
 
 The value for `notice.context.environment` when [creating a
 notice](https://docs.airbrake.io/docs/devops-tools/api/#create-notice-v3) can be
-set with the `:environment` config.
+set with the `:context_environment` config.
 
-Often it is easiest to configure `:environment` with some environment variable.
-However,  to get production notifications, the `environment` must be set to
-`"production"` (case independent).  Maybe your environment variable returns the
-value `"prod"`.  Set `:production_aliases` to a list of strings that should be
-converted into `"production"`.  The `config` example above will turn `"prod"`
-into `"production"`.
+Often it is easiest to configure `:context_environment` with some environment
+variable.  However,  to get production notifications, the `environment` must be
+set to `"production"` (case independent).  Maybe your environment variable
+returns the value `"prod"`.  Set `:production_aliases` to a list of strings that
+should be converted into `"production"`.  The `config` example above will turn
+`"prod"` into `"production"`.
 
 ### Logger metadata in the `session`
 

--- a/README.md
+++ b/README.md
@@ -16,28 +16,10 @@ Add `airbrake_client` to your dependencies:
 ```elixir
 defp deps do
   [
-    {:airbrake_client, "~> 0.10"}
+    {:airbrake_client, "~> 2.1"}
   ]
 end
 ```
-
-### Migrating from `airbrake`
-
-If you are switching from the original `airbrake` library:
-
-1. Replace the `:airbrake` dependency with the `:airbrake_client` dependency
-   above.
-    * You may want to start with version `~> 0.8.0` for maximum backwards
-      compatibility.
-1. Remove the `airbrake` dependency in your lockfile.
-    * Command: `mix deps.unlock --unused`
-    * If the dependency remains in the lockfile, check _all_ of your apps and
-      _all_ of your dependencies.
-1. Update your `config/*.exs` files to configure `:airbrake_client` instead of
-   `:airbrake`.
-    * A search-and-replace-in-project on `config :airbrake` can work really well.
-    * When you run your project(even running the tests), you should get a
-      complaint if you're still configuring `:airbrake`.
 
 ## Configuration
 
@@ -45,11 +27,13 @@ If you are switching from the original `airbrake` library:
 config :airbrake_client,
   api_key: System.get_env("AIRBRAKE_API_KEY"),
   project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
-  environment: Mix.env(),
+  environment: System.get_env("KUBERNETES_CLUSTER"),
   filter_parameters: ["password"],
   filter_headers: ["authorization"],
   session: :include_logger_metadata,
-  host: "https://api.airbrake.io" # or your Errbit host
+  json_encoder: Jason,
+  production_aliases: ["prod"],
+  host: "https://api.airbrake.io"
 
 config :logger,
   backends: [{Airbrake.LoggerBackend, :error}, :console]
@@ -67,20 +51,46 @@ Required configuration arguments:
 
 Optional configuration arguments:
 
-  * `:environment` - (binary or function returning binary) the environment that
-    will be attached to each reported exception.
-  * `:filter_parameters` - (list of binaries) allows to filter out sensitive
-    parameters such as passwords and tokens.
-  * `:filter_headers` - (list of binaries) filters HTTP headers.
-  * `:host` - (binary) the URL of the HTTP host; defaults to
+  * `:environment` - (binary or function returning binary) the deployment
+    environment; used to set `notice.context.environment`.  See the "Setting the
+    environment" section below.
+  * `:filter_parameters` - (list of strings) filters parameters that may map to
+    sensitive data such as passwords and tokens.
+  * `:filter_headers` - (list of strings) filters HTTP headers.
+  * `:host` - (string) the URL of the HTTP host; defaults to
     `https://api.airbrake.io`.
-  * `:ignore` - (MapSet of binary or function returning boolean or :all) allows
-    to ignore some or all exceptions.  See examples below.
+  * `:json_encoder` - (module) payload sent to Airbrake is JSON encoded by
+    calling `module.encode!/1`.
+    * You can use `Jason` from the [`jason`
+      library](https://hex.pm/packages/jason) or `Poison` from the [`poison`
+      library](https://hex.pm/packages/poison).
+    * `Poison` is used by default.
+  * `:ignore` - (MapSet of binary or function returning boolean or `:all`)
+    ignore some or all exceptions.  See examples below.
   * `:options` - (keyword list or function returning keyword list) values that
     are included in all reports to Airbrake.io.  See examples below.
+  * `:production_aliases` - (list of strings) a list of `"production"` aliases.
+    See the "Setting the environment" section below.
   * `:session` - can be set to `:include_logger_metadata` to include Logger
     metadata in the `session` field of the report; omit this option if you do
     not want Logger metadata.  See below for more information.
+
+See the ["Create notice
+v3"](https://docs.airbrake.io/docs/devops-tools/api/#create-notice-v3) section
+in the Airbrake API docs to understand some of these options better.
+
+### Setting the environment
+
+The value for `notice.context.environment` when [creating a
+notice](https://docs.airbrake.io/docs/devops-tools/api/#create-notice-v3) can be
+set with the `:environment` config.
+
+Often it is easiest to configure `:environment` with some environment variable.
+However,  to get production notifications, the `environment` must be set to
+`"production"` (case independent).  Maybe your environment variable returns the
+value `"prod"`.  Set `:production_aliases` to a list of strings that should be
+converted into `"production"`.  The `config` example above will turn `"prod"`
+into `"production"`.
 
 ### Logger metadata in the `session`
 
@@ -207,3 +217,21 @@ Airbrake.monitor(Registered.Process.Name)
 The Elixir apps defined in `integration_test_apps` are used for testing
 different dependency scenarios.  If you make changes to the way `jason` or
 `poison` is used this library, you should consider adding tests to those apps.
+
+## Migrating from `airbrake`
+
+If you are switching from the original `airbrake` library:
+
+1. Replace the `:airbrake` dependency with the `:airbrake_client` dependency
+   above.
+    * You may want to start with version `~> 0.8.0` for maximum backwards
+      compatibility.
+1. Remove the `airbrake` dependency in your lockfile.
+    * Command: `mix deps.unlock --unused`
+    * If the dependency remains in the lockfile, check _all_ of your apps and
+      _all_ of your dependencies.
+1. Update your `config/*.exs` files to configure `:airbrake_client` instead of
+   `:airbrake`.
+    * A search-and-replace-in-project on `config :airbrake` can work really well.
+    * When you run your project(even running the tests), you should get a
+      complaint if you're still configuring `:airbrake`.

--- a/lib/airbrake.ex
+++ b/lib/airbrake.ex
@@ -92,4 +92,16 @@ defmodule Airbrake do
       end) |> Airbrake.monitor
   """
   defdelegate monitor(pid_or_reg_name), to: Airbrake.Worker
+
+  @doc """
+  Recursively turns structs into plain maps.  Use this to clean up data for an
+  Airbrake report.
+  """
+  defdelegate destruct(value), to: Airbrake.Utils
+
+  @doc """
+  Recursively turns tuples into lists.  Use this to clean up data for an
+  Airbrake report.
+  """
+  defdelegate detuple(value), to: Airbrake.Utils
 end

--- a/lib/airbrake/config.ex
+++ b/lib/airbrake/config.ex
@@ -8,7 +8,7 @@ defmodule Airbrake.Config do
 
     @callback get(atom(), any()) :: any()
 
-    @callback env :: String.t()
+    @callback context_environment :: String.t()
 
     @callback hostname :: String.t()
   end
@@ -25,8 +25,8 @@ defmodule Airbrake.Config do
 
   # Returns the name of the environment.
   @impl Airbrake.Config.Behaviour
-  def env do
-    case Application.get_env(:airbrake_client, :environment) do
+  def context_environment(config \\ __MODULE__) do
+    case config.get(:context_environment) || config.get(:environment) do
       nil -> hostname()
       {:system, var} -> System.get_env(var, hostname())
       atom_env when is_atom(atom_env) -> to_string(atom_env)

--- a/lib/airbrake/config.ex
+++ b/lib/airbrake/config.ex
@@ -26,13 +26,18 @@ defmodule Airbrake.Config do
   # Returns the name of the environment.
   @impl Airbrake.Config.Behaviour
   def context_environment(config \\ __MODULE__) do
-    case config.get(:context_environment) || config.get(:environment) do
-      nil -> hostname()
-      {:system, var} -> System.get_env(var, hostname())
-      atom_env when is_atom(atom_env) -> to_string(atom_env)
-      str_env when is_binary(str_env) -> str_env
-      fun_env when is_function(fun_env) -> fun_env.()
-    end
+    config_context_environment =
+      case config.get(:context_environment) || config.get(:environment) do
+        nil -> hostname()
+        {:system, var} -> System.get_env(var, hostname())
+        atom_env when is_atom(atom_env) -> to_string(atom_env)
+        str_env when is_binary(str_env) -> str_env
+        fun_env when is_function(fun_env) -> fun_env.()
+      end
+
+    if config_context_environment in config.get(:production_aliases, []),
+      do: "production",
+      else: config_context_environment
   end
 
   # Returns a hostname.

--- a/lib/airbrake/payload/builder.ex
+++ b/lib/airbrake/payload/builder.ex
@@ -16,7 +16,7 @@ defmodule Airbrake.Payload.Builder do
     config = get_config(opts)
 
     Map.merge(
-      %{environment: config.env(), hostname: config.hostname()},
+      %{environment: config.context_environment(), hostname: config.hostname()},
       opts |> Keyword.get(:context, %{}) |> Enum.into(%{})
     )
   end

--- a/lib/airbrake/utils.ex
+++ b/lib/airbrake/utils.ex
@@ -34,9 +34,6 @@ defmodule Airbrake.Utils do
       else: {k, filter(v, filtered_attributes)}
   end
 
-  @doc """
-  Turns tuples into lists for JSON serialization of Airbrake payloads
-  """
   def detuple(%module{} = struct) do
     fields = struct |> Map.from_struct() |> detuple()
     struct(module, fields)
@@ -58,9 +55,6 @@ defmodule Airbrake.Utils do
     other
   end
 
-  @doc """
-  Recursively breaks down structs for JSON serialization of Airbrake payloads
-  """
   def destruct(%_module{} = struct) do
     struct |> Map.from_struct() |> destruct()
   end

--- a/test/airbrake/config_test.exs
+++ b/test/airbrake/config_test.exs
@@ -1,0 +1,38 @@
+defmodule Airbrake.ConfigTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Airbrake.Config
+
+  import Airbrake.Test.DataGenerator
+  import Mox
+
+  setup :verify_on_exit!
+
+  describe "context_environment/0" do
+    property "returns string from :context_environment of config" do
+      check all context_environment <- context_environment(),
+                environment <- context_environment(),
+                context_environment != environment do
+        stub(MockConfig, :get, fn
+          :environment -> environment
+          :context_environment -> context_environment
+        end)
+
+        assert Config.context_environment(MockConfig) == context_environment
+        assert Config.context_environment(MockConfig) != environment
+      end
+    end
+
+    property "returns string from :environment of config" do
+      check all environment <- context_environment() do
+        stub(MockConfig, :get, fn
+          :environment -> environment
+          :context_environment -> nil
+        end)
+
+        assert Config.context_environment(MockConfig) == environment
+      end
+    end
+  end
+end

--- a/test/airbrake/config_test.exs
+++ b/test/airbrake/config_test.exs
@@ -14,10 +14,12 @@ defmodule Airbrake.ConfigTest do
       check all context_environment <- context_environment(),
                 environment <- context_environment(),
                 context_environment != environment do
-        stub(MockConfig, :get, fn
+        MockConfig
+        |> stub(:get, fn
           :environment -> environment
           :context_environment -> context_environment
         end)
+        |> stub(:get, fn :production_aliases, [] -> [] end)
 
         assert Config.context_environment(MockConfig) == context_environment
         assert Config.context_environment(MockConfig) != environment
@@ -26,13 +28,42 @@ defmodule Airbrake.ConfigTest do
 
     property "returns string from :environment of config" do
       check all environment <- context_environment() do
-        stub(MockConfig, :get, fn
+        MockConfig
+        |> stub(:get, fn
           :environment -> environment
           :context_environment -> nil
         end)
+        |> stub(:get, fn :production_aliases, [] -> [] end)
 
         assert Config.context_environment(MockConfig) == environment
       end
     end
+
+    property "translates production_aliases to production" do
+      check all production_environments <- list_of(random_environment(), min_length: 10),
+                context_environment <- member_of(production_environments) do
+        MockConfig
+        |> stub(:get, fn :context_environment -> context_environment end)
+        |> stub(:get, fn :production_aliases, [] -> production_environments end)
+
+        assert Config.context_environment(MockConfig) == "production"
+      end
+    end
+
+    property "no translation if not in production_aliases" do
+      check all production_environments <- list_of(random_environment(), min_length: 10),
+                context_environment <- random_environment(),
+                context_environment not in production_environments do
+        MockConfig
+        |> stub(:get, fn :context_environment -> context_environment end)
+        |> stub(:get, fn :production_aliases, [] -> production_environments end)
+
+        assert Config.context_environment(MockConfig) == context_environment
+      end
+    end
+  end
+
+  defp random_environment do
+    string(:alphanumeric, min_length: 1)
   end
 end

--- a/test/airbrake/payload/builder_test.exs
+++ b/test/airbrake/payload/builder_test.exs
@@ -13,23 +13,24 @@ defmodule Airbrake.Payload.BuilderTest do
     property "builds default/initial context using env and hostname from config" do
       opts = [config: MockConfig]
 
-      check all env <- env(),
+      check all context_environment <- context_environment(),
                 hostname <- hostname() do
         MockConfig
-        |> stub(:env, fn -> env end)
+        |> stub(:context_environment, fn -> context_environment end)
         |> stub(:hostname, fn -> hostname end)
 
-        assert Builder.build(:context, opts) == %{environment: env, hostname: hostname}
+        assert Builder.build(:context, opts) ==
+                 %{environment: context_environment, hostname: hostname}
       end
     end
 
     property "can add more context" do
-      check all env <- env(),
+      check all context_environment <- context_environment(),
                 hostname <- hostname(),
                 foo <- one_of([integer(), string(:alphanumeric)]),
                 bar <- one_of([integer(), string(:alphanumeric)]) do
         MockConfig
-        |> stub(:env, fn -> env end)
+        |> stub(:context_environment, fn -> context_environment end)
         |> stub(:hostname, fn -> hostname end)
 
         opts = [
@@ -38,7 +39,7 @@ defmodule Airbrake.Payload.BuilderTest do
         ]
 
         assert Builder.build(:context, opts) == %{
-                 environment: env,
+                 environment: context_environment,
                  hostname: hostname,
                  foo: foo,
                  bar: bar
@@ -47,12 +48,12 @@ defmodule Airbrake.Payload.BuilderTest do
     end
 
     property "can add more context with keyword list" do
-      check all env <- env(),
+      check all context_environment <- context_environment(),
                 hostname <- hostname(),
                 foo <- one_of([integer(), string(:alphanumeric)]),
                 bar <- one_of([integer(), string(:alphanumeric)]) do
         MockConfig
-        |> stub(:env, fn -> env end)
+        |> stub(:context_environment, fn -> context_environment end)
         |> stub(:hostname, fn -> hostname end)
 
         opts = [
@@ -61,7 +62,7 @@ defmodule Airbrake.Payload.BuilderTest do
         ]
 
         assert Builder.build(:context, opts) == %{
-                 environment: env,
+                 environment: context_environment,
                  hostname: hostname,
                  foo: foo,
                  bar: bar
@@ -70,22 +71,22 @@ defmodule Airbrake.Payload.BuilderTest do
     end
 
     property "context in opts overwrites defaults" do
-      check all env <- env(),
+      check all context_environment <- context_environment(),
                 hostname <- hostname(),
-                opts_env <- env(),
+                opts_context_environment <- context_environment(),
                 opts_hostname <- hostname(),
                 foo <- integer() do
         MockConfig
-        |> stub(:env, fn -> env end)
+        |> stub(:context_environment, fn -> context_environment end)
         |> stub(:hostname, fn -> hostname end)
 
         opts = [
           config: MockConfig,
-          context: %{foo: foo, environment: opts_env, hostname: opts_hostname}
+          context: %{foo: foo, environment: opts_context_environment, hostname: opts_hostname}
         ]
 
         assert Builder.build(:context, opts) == %{
-                 environment: opts_env,
+                 environment: opts_context_environment,
                  hostname: opts_hostname,
                  foo: foo
                }

--- a/test/airbrake/payload/builder_test.exs
+++ b/test/airbrake/payload/builder_test.exs
@@ -3,6 +3,7 @@ defmodule Airbrake.Payload.BuilderTest do
   use ExUnitProperties
 
   import Mox
+  import Airbrake.Test.DataGenerator
 
   alias Airbrake.Payload.Builder
 
@@ -274,17 +275,5 @@ defmodule Airbrake.Payload.BuilderTest do
     defp session_does_not_includes_metadata do
       stub(MockConfig, :get, fn :session -> nil end)
     end
-  end
-
-  defp string_key do
-    string(:alphanumeric, min_length: 3)
-  end
-
-  defp env do
-    member_of(["dev", "uat", "staging", "prod"])
-  end
-
-  defp hostname do
-    string(:alphanumeric, min_length: 3)
   end
 end

--- a/test/support/data_generator.ex
+++ b/test/support/data_generator.ex
@@ -1,0 +1,19 @@
+defmodule Airbrake.Test.DataGenerator do
+  @moduledoc """
+  Functions to generate data for property tests.
+  """
+
+  import StreamData
+
+  def string_key do
+    string(:alphanumeric, min_length: 3)
+  end
+
+  def context_environment do
+    member_of(["dev", "development", "uat", "staging", "prod", "production"])
+  end
+
+  def hostname do
+    string(:alphanumeric, min_length: 3)
+  end
+end


### PR DESCRIPTION
Airbrake has filters for production environments, but the `notice.context.environment` _must_ be set to `"production"` (case independent) for these notification filters to work.

This PR does a few things:
* `notice.context.environment` is set using the `:context_environment` config option.
    * The option used to be called `:environment`, but this is ambiguous.
    * `:environment` is now an alias for `:context_environment`.
* `:production_aliases` is a new config options.
    * Set to a list of strings.
    * If the context environment is in this list of strings, `notice.context.environment` is set to `"production"`.

This is not getting a release because another change is coming very soon.