### PR TITLE
Handle stacktrace entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.1 (2025-01-04)
+
+### Bug fixes
+
+* Handles a stacktrace entry that includes unexpected values.
+
 ## v2.2.0 (2024-05-10)
 
 ### Enhancements

--- a/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
+++ b/integration_test_apps/jason_only_app/test/jason_only_app_test.exs
@@ -39,7 +39,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => nil,
                "session" => nil
@@ -88,7 +88,7 @@ defmodule JasonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
+++ b/integration_test_apps/poison_only_app/test/poison_only_app_test.exs
@@ -40,7 +40,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => nil,
                "session" => nil
@@ -89,7 +89,7 @@ defmodule PoisonOnlyAppTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}

--- a/lib/airbrake/payload/backtrace.ex
+++ b/lib/airbrake/payload/backtrace.ex
@@ -4,18 +4,13 @@ defmodule Airbrake.Payload.Backtrace do
   def from_stacktrace(stacktrace),
     do: Enum.map(stacktrace, &from_stacktrace_entry/1)
 
-  def from_stacktrace_entry({module, function, args, []}) do
-    %{
-      file: "unknown",
-      line: 0,
-      function: "#{format_module(module)}.#{function}#{format_args(args)}"
-    }
-  end
+  def from_stacktrace_entry({module, function, args, opts}) do
+    file = Keyword.get(opts, :file, ~c"unknown")
+    line = Keyword.get(opts, :line, 0)
 
-  def from_stacktrace_entry({module, function, args, [file: file, line: line_number]}) do
     %{
       file: file |> List.to_string(),
-      line: line_number,
+      line: line,
       function: "#{format_module(module)}.#{function}#{format_args(args)}"
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake_client,
-      version: "2.2.0",
+      version: "2.2.1",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -48,7 +48,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "2.2.0"
+                 version: "2.2.1"
                }
              } = Payload.new(exception, stacktrace)
     end
@@ -105,7 +105,7 @@ defmodule Airbrake.PayloadTest do
                notifier: %{
                  name: "Airbrake Client",
                  url: "https://github.com/CityBaseInc/airbrake_client",
-                 version: "2.2.0"
+                 version: "2.2.1"
                }
              } = Payload.new(@exception, @stacktrace)
     end
@@ -198,7 +198,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => nil,
                "session" => nil
@@ -242,7 +242,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}
@@ -281,7 +281,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => nil,
                "session" => nil
@@ -325,7 +325,7 @@ defmodule Airbrake.PayloadTest do
                "notifier" => %{
                  "name" => "Airbrake Client",
                  "url" => "https://github.com/CityBaseInc/airbrake_client",
-                 "version" => "2.2.0"
+                 "version" => "2.2.1"
                },
                "params" => %{"foo" => 55},
                "session" => %{"foo" => 555}


### PR DESCRIPTION
The pattern matching for `Airbrake.Payload.Backtrace.from_stacktrace_entry/1` is rather particular.  It's worked for a very long time until we had an app that generated a stacktrace entry like this:

```
{
  Ecto.Adapters.SQL, 
  :raise_sql_call_error, 
  1, 
  [
    file: ~c"lib/ecto/adapters/sql.ex",
    line: 1078, 
    error_info: %{module: Exception}
  ]
}
```

Our pattern matching couldn't handle the `:error_info` entry.  This PR does no pattern match on the keyword list; instead, we use `Keyword.get/3` to get `:file` and `:line` with default values.