### PR TITLE
WCHK-2230 improve test coverage for Airbrake.LoggerBackend

### DIFF
--- a/test/airbrake/logger_backend_test.exs
+++ b/test/airbrake/logger_backend_test.exs
@@ -35,5 +35,60 @@ defmodule Airbrake.LoggerBackendTest do
 
       assert_receive(url: _url, payload: _http_payload)
     end
+
+    test "raises Airbrake for RuntimeError from raise" do
+      caller = self()
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        assert payload =~ "\"type\":\"RuntimeError\""
+        assert payload =~ "\"message\":\"test exception\""
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      capture_log(fn ->
+        try do
+          raise "test exception"
+        rescue
+          e ->
+            Logger.error(Exception.format(:error, e, __STACKTRACE__))
+        end
+      end)
+
+      assert_receive(url: _url, payload: _http_payload)
+    end
+
+    test "raises Airbrake for ArgumentError" do
+      caller = self()
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        assert payload =~ "\"type\":\"ArgumentError\""
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      capture_log(fn ->
+        try do
+          Integer.to_string(1.0)
+        rescue
+          e ->
+            Logger.error(Exception.format(:error, e, __STACKTRACE__))
+        end
+      end)
+
+      assert_receive(url: _url, payload: _http_payload)
+    end
+
+    test "does NOT raise Airbrake for plain text Logger.error" do
+      stub(HTTPMock, :post, fn _, _, _ ->
+        flunk("HTTPMock.post should not be called for plain text error logs")
+      end)
+
+      capture_log(fn ->
+        Logger.error("foo bar")
+      end)
+
+      refute_receive(_any, 100)
+    end
   end
 end


### PR DESCRIPTION
While updating the libraries for schedule service, we found that logger `:backends` was deprecated and as a result, we had to update the way we were configuring airbrake logs. During this investigation, we found that `Logger.error(...)` does not and should not trigger an airbrake notice, however we had no test coverage to show this explicitly. This PR introduces tests from the investigation found here: https://github.com/CityBaseInc/schedule_service/pull/399